### PR TITLE
Restore 4 uniqueness removed in #998 where no xsd:key covers it (+ must-fail guards)

### DIFF
--- a/.github/scripts/validate-should-fail.sh
+++ b/.github/scripts/validate-should-fail.sh
@@ -35,5 +35,6 @@ echo "Checking NeTEx 'should-fail' negative examples ..."
 assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 assert_rejected examples/should-fail/duplicate-CalendarDate.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 assert_rejected examples/should-fail/duplicate-ValidBetween.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
+assert_rejected examples/should-fail/duplicate-ValidityPeriod.xml       xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 
 exit "${fail}"

--- a/.github/scripts/validate-should-fail.sh
+++ b/.github/scripts/validate-should-fail.sh
@@ -34,5 +34,6 @@ assert_rejected() { # <file> <schema> <expected error substring>
 echo "Checking NeTEx 'should-fail' negative examples ..."
 assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 assert_rejected examples/should-fail/duplicate-CalendarDate.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
+assert_rejected examples/should-fail/duplicate-ValidBetween.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 
 exit "${fail}"

--- a/.github/scripts/validate-should-fail.sh
+++ b/.github/scripts/validate-should-fail.sh
@@ -13,16 +13,25 @@ XMLLINT="${XMLLINT_BIN:-${SCRIPT_DIR}/xmllint}"
 cd "${ROOT_DIR}"
 
 fail=0
-assert_rejected() { # <file> <schema> <error-pattern>
-  if "${XMLLINT}" --noout --schema "$2" "$1" 2>&1 | grep -q "$3"; then
-    echo "OK               $1"
+# Behaviour assertion, parameterised by the caller: the document must be REJECTED, and
+# the rejection output must contain <expected>. We test the outcome, not how it is
+# enforced - passing "Duplicate key-sequence" accepts a unique, a key or a rename alike,
+# as long as the duplicate is caught. Each future test declares its own <expected>.
+# Fails closed: accepted, wrong reason, or xmllint not running all count as failures.
+assert_rejected() { # <file> <schema> <expected error substring>
+  out=$("${XMLLINT}" --noout --schema "$2" "$1" 2>&1); st=$?
+  if [ "${st}" -eq 0 ]; then
+    echo "SHOULD HAVE FAILED  $1 — accepted (must be rejected)"
+    fail=1
+  elif printf '%s\n' "${out}" | grep -q "$3"; then
+    echo "OK                  $1"
   else
-    echo "SHOULD HAVE FAILED  $1 — not rejected by '$3' (constraint missing?)"
+    echo "ERROR               $1 — rejected, but not matching '$3' (unrelated error / xmllint failure?)"
     fail=1
   fi
 }
 
 echo "Checking NeTEx 'should-fail' negative examples ..."
-assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd GroupOfLinkSequences_UniqueBy_Id_Version
+assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 
 exit "${fail}"

--- a/.github/scripts/validate-should-fail.sh
+++ b/.github/scripts/validate-should-fail.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Negative examples: documents that MUST be rejected by the schema.
+# Each case greps the EXACT expected constraint name, so dropping that constraint
+# (document wrongly accepted) fails the build and can't be masked by another error.
+
+set -u
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$( cd -- "${SCRIPT_DIR}/../.." &> /dev/null && pwd )
+# CI uses the vendored 2025 Linux x86-64 xmllint ("Temporary xmllint master",
+# https://github.com/TransmodelEcosystem/NeTEx/pull/915); set XMLLINT_BIN to a local
+# xmllint to run this on any other OS or CPU architecture (macOS, Windows, ARM, ...).
+XMLLINT="${XMLLINT_BIN:-${SCRIPT_DIR}/xmllint}"
+cd "${ROOT_DIR}"
+
+fail=0
+assert_rejected() { # <file> <schema> <error-pattern>
+  if "${XMLLINT}" --noout --schema "$2" "$1" 2>&1 | grep -q "$3"; then
+    echo "OK               $1"
+  else
+    echo "SHOULD HAVE FAILED  $1 — not rejected by '$3' (constraint missing?)"
+    fail=1
+  fi
+}
+
+echo "Checking NeTEx 'should-fail' negative examples ..."
+assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd GroupOfLinkSequences_UniqueBy_Id_Version
+
+exit "${fail}"

--- a/.github/scripts/validate-should-fail.sh
+++ b/.github/scripts/validate-should-fail.sh
@@ -33,5 +33,6 @@ assert_rejected() { # <file> <schema> <expected error substring>
 
 echo "Checking NeTEx 'should-fail' negative examples ..."
 assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd "Duplicate key-sequence"
+assert_rejected examples/should-fail/duplicate-CalendarDate.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
 
 exit "${fail}"

--- a/.github/scripts/validate-should-fail.sh
+++ b/.github/scripts/validate-should-fail.sh
@@ -1,40 +1,49 @@
 #!/bin/bash
 # Negative examples: documents that MUST be rejected by the schema.
-# Each case greps the EXACT expected constraint name, so dropping that constraint
-# (document wrongly accepted) fails the build and can't be masked by another error.
+#
+# Each case is "<file>|<expected error substring>". We assert BEHAVIOUR (the
+# document is rejected, and its output contains the declared substring) - not a
+# specific constraint name, and each case carries its own clause.
+#
+# All cases share ONE schema and are validated in a SINGLE xmllint call (one
+# compile for many files) to stay fast. Fails closed: accepted, wrong reason, or
+# xmllint not running all count as failures.
+#
+# CI uses the vendored 2025 Linux x86-64 xmllint ("Temporary xmllint master",
+# https://github.com/TransmodelEcosystem/NeTEx/pull/915); set XMLLINT_BIN to a local
+# xmllint to run this on any other OS or CPU architecture (macOS, Windows, ARM, ...).
 
 set -u
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR=$( cd -- "${SCRIPT_DIR}/../.." &> /dev/null && pwd )
-# CI uses the vendored 2025 Linux x86-64 xmllint ("Temporary xmllint master",
-# https://github.com/TransmodelEcosystem/NeTEx/pull/915); set XMLLINT_BIN to a local
-# xmllint to run this on any other OS or CPU architecture (macOS, Windows, ARM, ...).
 XMLLINT="${XMLLINT_BIN:-${SCRIPT_DIR}/xmllint}"
 cd "${ROOT_DIR}"
 
-fail=0
-# Behaviour assertion, parameterised by the caller: the document must be REJECTED, and
-# the rejection output must contain <expected>. We test the outcome, not how it is
-# enforced - passing "Duplicate key-sequence" accepts a unique, a key or a rename alike,
-# as long as the duplicate is caught. Each future test declares its own <expected>.
-# Fails closed: accepted, wrong reason, or xmllint not running all count as failures.
-assert_rejected() { # <file> <schema> <expected error substring>
-  out=$("${XMLLINT}" --noout --schema "$2" "$1" 2>&1); st=$?
-  if [ "${st}" -eq 0 ]; then
-    echo "SHOULD HAVE FAILED  $1 — accepted (must be rejected)"
-    fail=1
-  elif printf '%s\n' "${out}" | grep -q "$3"; then
-    echo "OK                  $1"
-  else
-    echo "ERROR               $1 — rejected, but not matching '$3' (unrelated error / xmllint failure?)"
-    fail=1
-  fi
-}
+SCHEMA="xsd/NeTEx_publication.xsd"
 
+# "<file>|<expected error substring>"
+CASES=(
+  "examples/should-fail/duplicate-GroupOfLinkSequences.xml|Duplicate key-sequence"
+  "examples/should-fail/duplicate-CalendarDate.xml|Duplicate key-sequence"
+  "examples/should-fail/duplicate-ValidBetween.xml|Duplicate key-sequence"
+  "examples/should-fail/duplicate-ValidityPeriod.xml|Duplicate key-sequence"
+)
+
+files=()
+for c in "${CASES[@]}"; do files+=("${c%%|*}"); done
+out=$("${XMLLINT}" --noout --schema "${SCHEMA}" "${files[@]}" 2>&1)
+
+fail=0
 echo "Checking NeTEx 'should-fail' negative examples ..."
-assert_rejected examples/should-fail/duplicate-GroupOfLinkSequences.xml xsd/NeTEx_publication.xsd "Duplicate key-sequence"
-assert_rejected examples/should-fail/duplicate-CalendarDate.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
-assert_rejected examples/should-fail/duplicate-ValidBetween.xml         xsd/NeTEx_publication.xsd "Duplicate key-sequence"
-assert_rejected examples/should-fail/duplicate-ValidityPeriod.xml       xsd/NeTEx_publication.xsd "Duplicate key-sequence"
+for c in "${CASES[@]}"; do
+  f="${c%%|*}"; expected="${c#*|}"
+  if printf '%s\n' "${out}" | grep -Fqx "${f} validates"; then
+    echo "SHOULD HAVE FAILED  ${f} — accepted (must be rejected)"; fail=1
+  elif printf '%s\n' "${out}" | grep -F "${f}:" | grep -q "${expected}"; then
+    echo "OK                  ${f}"
+  else
+    echo "ERROR               ${f} — rejected, but not matching '${expected}'"; fail=1
+  fi
+done
 
 exit "${fail}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Validate NeTEx XML examples
         run: ./.github/scripts/validate-examples.sh
 
+      - name: Validate negative examples (must-fail)
+        run: ./.github/scripts/validate-should-fail.sh
+
       - name: Commit changes
         uses: EndBug/add-and-commit@v9 # https://github.com/marketplace/actions/add-commit
         with:

--- a/examples/should-fail/README.md
+++ b/examples/should-fail/README.md
@@ -1,0 +1,7 @@
+# Negative examples (must-fail)
+
+Each file carries one deliberate defect and must therefore be **rejected** by the
+schema for a specific, expected reason. The cases — file, schema and expected
+constraint — are declared in `.github/scripts/validate-should-fail.sh` (run in CI).
+
+Run locally: `XMLLINT_BIN=$(which xmllint) ./.github/scripts/validate-should-fail.sh`

--- a/examples/should-fail/duplicate-CalendarDate.xml
+++ b/examples/should-fail/duplicate-CalendarDate.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0">
+	<PublicationTimestamp>2020-01-01T12:00:00Z</PublicationTimestamp>
+	<ParticipantRef>TEST</ParticipantRef>
+	<dataObjects>
+		<ServiceCalendarFrame version="1.0" id="TEST:ServiceCalendarFrame:1">
+			<operatingDays>
+				<OperatingDay version="1.0" id="TEST:OperatingDay:1"><CalendarDate>2020-01-01</CalendarDate></OperatingDay>
+				<OperatingDay version="1.0" id="TEST:OperatingDay:2"><CalendarDate>2020-01-01</CalendarDate></OperatingDay>
+			</operatingDays>
+		</ServiceCalendarFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/examples/should-fail/duplicate-CalendarDate.xml
+++ b/examples/should-fail/duplicate-CalendarDate.xml
@@ -5,8 +5,12 @@
 	<dataObjects>
 		<ServiceCalendarFrame version="1.0" id="TEST:ServiceCalendarFrame:1">
 			<operatingDays>
-				<OperatingDay version="1.0" id="TEST:OperatingDay:1"><CalendarDate>2020-01-01</CalendarDate></OperatingDay>
-				<OperatingDay version="1.0" id="TEST:OperatingDay:2"><CalendarDate>2020-01-01</CalendarDate></OperatingDay>
+				<OperatingDay version="1.0" id="TEST:OperatingDay:1">
+					<CalendarDate>2020-01-01</CalendarDate>
+				</OperatingDay>
+				<OperatingDay version="1.0" id="TEST:OperatingDay:2">
+					<CalendarDate>2020-01-01</CalendarDate>
+				</OperatingDay>
 			</operatingDays>
 		</ServiceCalendarFrame>
 	</dataObjects>

--- a/examples/should-fail/duplicate-GroupOfLinkSequences.xml
+++ b/examples/should-fail/duplicate-GroupOfLinkSequences.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0">
+	<PublicationTimestamp>2020-01-01T12:00:00Z</PublicationTimestamp>
+	<ParticipantRef>TEST</ParticipantRef>
+	<dataObjects>
+		<ResourceFrame version="1.0" id="TEST:ResourceFrame:1">
+			<groupsOfEntities>
+				<GroupOfLinkSequences version="1.0" id="TEST:GroupOfLinkSequences:1"/>
+				<GroupOfLinkSequences version="1.0" id="TEST:GroupOfLinkSequences:1"/>
+			</groupsOfEntities>
+		</ResourceFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/examples/should-fail/duplicate-ValidBetween.xml
+++ b/examples/should-fail/duplicate-ValidBetween.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0">
+	<PublicationTimestamp>2020-01-01T12:00:00Z</PublicationTimestamp>
+	<ParticipantRef>TEST</ParticipantRef>
+	<dataObjects>
+		<ResourceFrame version="1.0" id="TEST:ResourceFrame:1">
+			<ValidBetween id="TEST:ValidBetween:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidBetween>
+		</ResourceFrame>
+		<ServiceFrame version="1.0" id="TEST:ServiceFrame:1">
+			<ValidBetween id="TEST:ValidBetween:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidBetween>
+		</ServiceFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/examples/should-fail/duplicate-ValidBetween.xml
+++ b/examples/should-fail/duplicate-ValidBetween.xml
@@ -4,10 +4,14 @@
 	<ParticipantRef>TEST</ParticipantRef>
 	<dataObjects>
 		<ResourceFrame version="1.0" id="TEST:ResourceFrame:1">
-			<ValidBetween id="TEST:ValidBetween:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidBetween>
+			<ValidBetween id="TEST:ValidBetween:1" version="1.0">
+				<FromDate>2020-01-01T00:00:00Z</FromDate>
+			</ValidBetween>
 		</ResourceFrame>
 		<ServiceFrame version="1.0" id="TEST:ServiceFrame:1">
-			<ValidBetween id="TEST:ValidBetween:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidBetween>
+			<ValidBetween id="TEST:ValidBetween:1" version="1.0">
+				<FromDate>2020-01-01T00:00:00Z</FromDate>
+			</ValidBetween>
 		</ServiceFrame>
 	</dataObjects>
 </PublicationDelivery>

--- a/examples/should-fail/duplicate-ValidityPeriod.xml
+++ b/examples/should-fail/duplicate-ValidityPeriod.xml
@@ -7,11 +7,15 @@
 			<organisations>
 				<Authority version="1.0" id="TEST:Authority:1">
 					<Name>A</Name>
-					<ValidityPeriod id="TEST:ValidityPeriod:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidityPeriod>
+					<ValidityPeriod id="TEST:ValidityPeriod:1" version="1.0">
+						<FromDate>2020-01-01T00:00:00Z</FromDate>
+					</ValidityPeriod>
 				</Authority>
 				<Operator version="1.0" id="TEST:Operator:1">
 					<Name>B</Name>
-					<ValidityPeriod id="TEST:ValidityPeriod:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidityPeriod>
+					<ValidityPeriod id="TEST:ValidityPeriod:1" version="1.0">
+						<FromDate>2020-01-01T00:00:00Z</FromDate>
+					</ValidityPeriod>
 				</Operator>
 			</organisations>
 		</ResourceFrame>

--- a/examples/should-fail/duplicate-ValidityPeriod.xml
+++ b/examples/should-fail/duplicate-ValidityPeriod.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0">
+	<PublicationTimestamp>2020-01-01T12:00:00Z</PublicationTimestamp>
+	<ParticipantRef>TEST</ParticipantRef>
+	<dataObjects>
+		<ResourceFrame version="1.0" id="TEST:ResourceFrame:1">
+			<organisations>
+				<Authority version="1.0" id="TEST:Authority:1">
+					<Name>A</Name>
+					<ValidityPeriod id="TEST:ValidityPeriod:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidityPeriod>
+				</Authority>
+				<Operator version="1.0" id="TEST:Operator:1">
+					<Name>B</Name>
+					<ValidityPeriod id="TEST:ValidityPeriod:1" version="1.0"><FromDate>2020-01-01T00:00:00Z</FromDate></ValidityPeriod>
+				</Operator>
+			</organisations>
+		</ResourceFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2257,6 +2257,15 @@
 			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- =====ValidityCondition============================== -->
+		<!-- =====ValidityCondition unique========================== -->
+		<xsd:unique name="ValidityCondition_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [ValidityCondition Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:ValidityCondition | .//netex:ValidityTrigger | .//netex:ValidityRuleParameter | .//netex:ValidBetween"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
 		<!-- =====ValidityCondition Key ========================== -->
 		<xsd:keyref name="ValidityCondition_KeyRef" refer="netex:ValidityCondition_AnyVersionedKey">
 			<xsd:selector xpath=".//netex:ValidityConditionRef | .//netex:ValidityTriggerRef | .//netex:ValidityRuleParameterRef | .//netex:WithConditionRef"/>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -979,6 +979,15 @@
 			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- =====GroupOfLinkSequences============================== -->
+		<!-- =====GroupOfLinkSequences unique========================== -->
+		<xsd:unique name="GroupOfLinkSequences_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [GroupOfLinkSequences Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:GroupOfLinkSequences"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
 		<!-- =====SimpleFeature============================== -->
 		<!-- =====SimpleFeature Key ========================== -->
 		<xsd:keyref name="SimpleFeature_KeyRef" refer="netex:SimpleFeature_AnyVersionedKey">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -6515,6 +6515,15 @@
 			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- ===== UsageValidityPeriod Key ========================== -->
+		<!-- ===== UsageValidityPeriodting unique========================== -->
+		<xsd:unique name="UsageValidityPeriod">
+			<xsd:annotation>
+				<xsd:documentation>Every [UsageValidityPeriod Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:UsageValidityPeriod | .//netex:ValidityPeriod"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
 		<xsd:keyref name="UsageValidityPeriod_KeyRef" refer="netex:UsageValidityPeriod_AnyVersionedKey">
 			<xsd:selector xpath=".//netex:UsageValidityPeriodRef"/>
 			<xsd:field xpath="@ref"/>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2200,6 +2200,15 @@
 			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- =====OperatingDay============================== -->
+		<!-- =====OperatingDay unique==In Calendar======================== -->
+		<xsd:unique name="OperatingDay_UniqueCalendarDateInCalendar">
+			<xsd:annotation>
+				<xsd:documentation>Each date is only allowed once per calendar.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:ServiceCalendarFrame/netex:operatingDays/netex:OperatingDay"/>
+			<xsd:field xpath="netex:CalendarDate"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
 		<!-- =====OperatingDay Key ========================== -->
 		<xsd:keyref name="OperatingDay_KeyRef" refer="netex:OperatingDay_AnyVersionedKey">
 			<xsd:selector xpath=".//netex:OperatingDayRef | .//netex:FromOperatingDayRef | .//netex:ToOperatingDayRef"/>


### PR DESCRIPTION
**Scope of this PR**

- To be merged into #998 ("Remove unique constraints, because we have xsd:key").
- Undoes 4 of #998's removals — the cases where no `xsd:key` enforces the uniqueness: `GroupOfLinkSequences`, `OperatingDay`, `ValidBetween` and `ValidityPeriod`.
- Adds must-fail examples (`examples/should-fail/`) that prove the uniqueness is no longer enforced — we can decide later what to do with them (e.g. keep them as permanent CI guards).

This PR **restores the missing `xsd:unique`** — otherwise `v2.0.1` would not be a *correct* optimisation, since it would silently drop validation that `v2.0.0` had (these four were enforced in `v2.0.0` via `xsd:unique`).

It does **not** replace them with `xsd:key`. For `GroupOfLinkSequences`, afaik `xsd:key` was there before `v2.0.0`,  but has removed by #721/#462 before `v2.0.0` was released (which is why it's important to avoid also removing unique here).

Whether to (re)introduce keys is a separate discussion we can have, but not the scope of this PR (and maybe not for a `v2.0.1` bug fix either).
