### PR TITLE
Removed excessive spaces from enum values

### DIFF
--- a/examples/functions/deckPlans/DeckPlans-Example_train.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example_train.xml
@@ -4639,7 +4639,7 @@ The train reverse in  the station and departs, oriented backwards to the right
 								</PathLinkInSequence>
 								<PathLinkInSequence version="any" id="xx:xx:PLIS-station_765@SPE-entrance_1+BP-quay_2_boarding_point_c@by_stairs-2">
 									<SitePathLinkRef version="any" ref="xx:SPL-station_765@PJ-ticket_hall_middle+SPE-stairs_to_q1_and_q2_top"/>
-									<Heading>left </Heading>
+									<Heading>left</Heading>
 									<Transition>level</Transition>
 									<Instruction>Turn left and proceed to entrance to platforms 1 and  2</Instruction>
 								</PathLinkInSequence>

--- a/examples/functions/stopPlace/FX-PI-01_UK_TBD_STOP-OFFER_910GWIMBLDN-accessibility_20140601.xml
+++ b/examples/functions/stopPlace/FX-PI-01_UK_TBD_STOP-OFFER_910GWIMBLDN-accessibility_20140601.xml
@@ -677,15 +677,15 @@ Changes
 								</limitations>
 								<suitabilities>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S01" version="001">
-										<MobilityNeed> wheelchair</MobilityNeed>
+										<MobilityNeed>wheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S02">
-										<MobilityNeed>  assistedWheelchair</MobilityNeed>
+										<MobilityNeed>assistedWheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S03">
-										<MobilityNeed> motorizedWheelchair</MobilityNeed>
+										<MobilityNeed>motorizedWheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S04">
@@ -3021,7 +3021,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+5n6-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3220,7 +3220,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3437,7 +3437,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+9n10-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3660,7 +3660,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@DL+7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToQuay</NavigationType>
@@ -3893,7 +3893,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@5n6+7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -4124,7 +4124,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@5n6+9n10-notacc-01">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -4355,7 +4355,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@7n8+9n10-notacc-01">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToQuay</NavigationType>
@@ -5315,7 +5315,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+DL_is-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>streetToQuay</NavigationType>
@@ -5375,7 +5375,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@DL+A1-EE1-is-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToStreet</NavigationType>
@@ -6821,7 +6821,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to02_both_N01_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -6905,7 +6905,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to04_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -6989,7 +6989,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7030,7 +7030,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7421,7 +7421,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_03to04_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7508,7 +7508,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_03to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7552,7 +7552,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_03to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7864,7 +7864,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_05to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7908,7 +7908,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_05to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>

--- a/examples/functions/stopPlace/Netex_04_Stops_SimpleStation_1.xml
+++ b/examples/functions/stopPlace/Netex_04_Stops_SimpleStation_1.xml
@@ -308,7 +308,7 @@ B. Frames and grouping
 									<TopographicPlaceRef version="01" ref="topat:E0034"/>
 								</Qualify>
 							</Descriptor>
-							<TopographicPlaceType>  village</TopographicPlaceType>
+							<TopographicPlaceType>village</TopographicPlaceType>
 							<PlaceCentre> false</PlaceCentre>
 							<CountryRef ref="at"/>
 							<ParentTopographicPlaceRef version="01" ref="topat:E0034"/>
@@ -318,7 +318,7 @@ B. Frames and grouping
 							<Descriptor version="01" id="topat:E0034">
 								<Name lang="de">Tyrol</Name>
 							</Descriptor>
-							<TopographicPlaceType> province</TopographicPlaceType>
+							<TopographicPlaceType>province</TopographicPlaceType>
 							<PlaceCentre> false</PlaceCentre>
 							<CountryRef ref="at"/>
 						</TopographicPlace>
@@ -856,7 +856,7 @@ B. Frames and grouping
 										<AccessSummary version="any" id="ztb:NP_bh0023@Bus-Q1+Rail@Q2-E2tr">
 											<AccessFeatureType>crossing</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> downAndUp</Transition>
+											<Transition>downAndUp</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -883,7 +883,7 @@ B. Frames and grouping
 										<AccessSummary version="any" id="ztb:NP_bh0023@A1+Bus-Q1">
 											<AccessFeatureType>crossing</AccessFeatureType>
 											<Count>1</Count>
-											<Transition>  level</Transition>
+											<Transition>level</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -951,7 +951,7 @@ B. Frames and grouping
 										<AccessSummary version="any" id="ztb:NP_bh0023@A1+Rail@Q2-E1tr">
 											<AccessFeatureType>crossing</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> downAndUp</Transition>
+											<Transition>downAndUp</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -992,7 +992,7 @@ B. Frames and grouping
 										<AccessSummary version="any" id="ztb:NP_bh0023@Rail@Q2+A1">
 											<AccessFeatureType>crossing</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> downAndUp</Transition>
+											<Transition>downAndUp</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -1043,7 +1043,7 @@ B. Frames and grouping
 										<AccessSummary version="any" id="ztb:bh0023@Rail@Q1+Rail@Q2">
 											<AccessFeatureType>crossing</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> downAndUp</Transition>
+											<Transition>downAndUp</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -1080,7 +1080,7 @@ B. Frames and grouping
 										<AccessSummary version="any" id="ztb:bh0023@Rail@Q2+Rail@Q1">
 											<AccessFeatureType>crossing</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> downAndUp</Transition>
+											<Transition>downAndUp</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>

--- a/examples/functions/stopPlace/Netex_10_StopPlace_uk_ComplexStation_Wimbledon_1.xml
+++ b/examples/functions/stopPlace/Netex_10_StopPlace_uk_ComplexStation_Wimbledon_1.xml
@@ -820,15 +820,15 @@ Changes
 								</limitations>
 								<suitabilities>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S01">
-										<MobilityNeed> wheelchair</MobilityNeed>
+										<MobilityNeed>wheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S02">
-										<MobilityNeed>  assistedWheelchair</MobilityNeed>
+										<MobilityNeed>assistedWheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S03">
-										<MobilityNeed> motorizedWheelchair</MobilityNeed>
+										<MobilityNeed>motorizedWheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1@S04">
@@ -3130,7 +3130,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+5n6-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3346,7 +3346,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3583,7 +3583,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+9n10-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3827,7 +3827,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@DL+7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToQuay</NavigationType>
@@ -4082,7 +4082,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@5n6+7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -4333,7 +4333,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@5n6+9n10-notacc-01">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -4585,7 +4585,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@7n8+9n10-notacc-01">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToQuay</NavigationType>
@@ -5559,7 +5559,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@A1-EE1+DL_is-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>streetToQuay</NavigationType>
@@ -5625,7 +5625,7 @@ Changes
 										<AccessSummary version="any" id="tbd:9100WIMBLDN@DL+A1-EE1-is-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToStreet</NavigationType>
@@ -7143,7 +7143,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to02_both_N01_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7227,7 +7227,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to04_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7311,7 +7311,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7352,7 +7352,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_01to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7743,7 +7743,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_03to04_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7830,7 +7830,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_03to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7874,7 +7874,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_03to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -8186,7 +8186,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_05to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -8230,7 +8230,7 @@ Changes
 										<AccessSummary version="any" id="tbd:wimcon_05to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>

--- a/examples/functions/stopPlace/Netex_10_StopPlace_withParking_1.xml
+++ b/examples/functions/stopPlace/Netex_10_StopPlace_withParking_1.xml
@@ -813,15 +813,15 @@ Changes
 								</limitations>
 								<suitabilities>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1_S01" version="001">
-										<MobilityNeed> wheelchair</MobilityNeed>
+										<MobilityNeed>wheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1_S02" version="001">
-										<MobilityNeed>  assistedWheelchair</MobilityNeed>
+										<MobilityNeed>assistedWheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1_S03" version="001">
-										<MobilityNeed> motorizedWheelchair</MobilityNeed>
+										<MobilityNeed>motorizedWheelchair</MobilityNeed>
 										<Suitable>suitable</Suitable>
 									</Suitability>
 									<Suitability id="naptStop:910GWIMBLDN_Ac1_S04" version="001">
@@ -3133,7 +3133,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_A1-EE1_to_5n6-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3332,7 +3332,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_A1-EE1_to_7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3549,7 +3549,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_A1-EE1_to_9n10-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>hallToQuay</NavigationType>
@@ -3772,7 +3772,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_DL_to_7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToQuay</NavigationType>
@@ -4005,7 +4005,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_5n6_to_7n8-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -4236,7 +4236,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_5n6_to_9n10-notacc-01">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<TransferDuration>
@@ -4467,7 +4467,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_7n8_to_9n10-notacc-01">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToQuay</NavigationType>
@@ -5416,7 +5416,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_A1-EE1_to_DL_is-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>streetToQuay</NavigationType>
@@ -5476,7 +5476,7 @@ Changes
 										<AccessSummary version="any" id="nptg:9100WIMBLDN_DL_to_A1-EE1-is-notacc">
 											<AccessFeatureType>stairs</AccessFeatureType>
 											<Count>26</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 									<NavigationType>quayToStreet</NavigationType>
@@ -6970,7 +6970,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_01to02_both_N01_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7054,7 +7054,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_01to04_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7138,7 +7138,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_01to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7179,7 +7179,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_01to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7570,7 +7570,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_03to04_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7657,7 +7657,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_03to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -7701,7 +7701,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_03to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -8013,7 +8013,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_05to06_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>
@@ -8057,7 +8057,7 @@ Changes
 										<AccessSummary version="any" id="nptg:wimcon_05to07_both_01">
 											<AccessFeatureType>lift</AccessFeatureType>
 											<Count>1</Count>
-											<Transition> down</Transition>
+											<Transition>down</Transition>
 										</AccessSummary>
 									</summaries>
 								</NavigationPath>

--- a/examples/functions/timetable/Netex_01.4_Bus_SimpleTimetable_WithConnection.xml
+++ b/examples/functions/timetable/Netex_01.4_Bus_SimpleTimetable_WithConnection.xml
@@ -334,7 +334,7 @@ The Calendar is shown coded as
 											<Precision>12</Precision>
 										</Location>
 									</Centroid>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 									<BearingCompass>E</BearingCompass>
@@ -350,7 +350,7 @@ The Calendar is shown coded as
 											<Precision>12</Precision>
 										</Location>
 									</Centroid>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 									<BearingCompass>W</BearingCompass>
@@ -551,7 +551,7 @@ The Calendar is shown coded as
 											<Name>Can connect to LINE 4</Name>
 											<NoticeRef version="any" ref="hde:sj_24o@02"/>
 											<Mark>++3</Mark>
-											<PublicityChannel> all</PublicityChannel>
+											<PublicityChannel>all</PublicityChannel>
 											<Advertised>true</Advertised>
 										</NoticeAssignment>
 									</noticeAssignments>
@@ -1062,7 +1062,7 @@ The Calendar is shown coded as
 											<Name>Can connect to LINE 4</Name>
 											<NoticeRef version="any" ref="hde:sj_24o@02"/>
 											<Mark>++3</Mark>
-											<PublicityChannel> all</PublicityChannel>
+											<PublicityChannel>all</PublicityChannel>
 											<Advertised>true</Advertised>
 										</NoticeAssignment>
 									</noticeAssignments>
@@ -1091,7 +1091,7 @@ The Calendar is shown coded as
 									<NoticeRef version="any" ref="hde:sj_46o_01"/>
 									<JourneyPatternRef version="any" ref="hde:sjp_46o"/>
 									<Mark>++1</Mark>
-									<PublicityChannel> all</PublicityChannel>
+									<PublicityChannel>all</PublicityChannel>
 									<Advertised>true</Advertised>
 								</NoticeAssignment>
 							</noticeAssignments>
@@ -1178,7 +1178,7 @@ The Calendar is shown coded as
 											<StartPointInPatternRef version="any" ref="hde:pijp_46o_02"/>
 											<EndPointInPatternRef version="any" ref="hde:pijp_46o_03"/>
 											<Mark>++2</Mark>
-											<PublicityChannel> all</PublicityChannel>
+											<PublicityChannel>all</PublicityChannel>
 											<Advertised>true</Advertised>
 										</NoticeAssignment>
 									</noticeAssignments>
@@ -1287,7 +1287,7 @@ The Calendar is shown coded as
 											<StartPointInPatternRef version="any" ref="hde:pijp_46o_02"/>
 											<EndPointInPatternRef version="any" ref="hde:pijp_46o_03"/>
 											<Mark>++2</Mark>
-											<PublicityChannel> all</PublicityChannel>
+											<PublicityChannel>all</PublicityChannel>
 											<Advertised>true</Advertised>
 										</NoticeAssignment>
 									</noticeAssignments>

--- a/examples/functions/timetable/Netex_07.1_Bus_FlexibleTimetable_ZonesOnly.xml
+++ b/examples/functions/timetable/Netex_07.1_Bus_FlexibleTimetable_ZonesOnly.xml
@@ -125,7 +125,7 @@ The Calendar is shown coded as
 											</gml:LinearRing>
 										</gml:exterior>
 									</gml:Polygon>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 								</FlexibleArea>
@@ -164,7 +164,7 @@ The Calendar is shown coded as
 											</gml:LinearRing>
 										</gml:exterior>
 									</gml:Polygon>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 								</FlexibleArea>
@@ -188,7 +188,7 @@ The Calendar is shown coded as
 											</gml:LinearRing>
 										</gml:exterior>
 									</gml:Polygon>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 								</FlexibleArea>

--- a/examples/functions/timetable/Netex_07.2_Bus_FlexibleTimetable_WithPattern.xml
+++ b/examples/functions/timetable/Netex_07.2_Bus_FlexibleTimetable_WithPattern.xml
@@ -200,7 +200,7 @@ The Calendar is shown coded as
 											</gml:LinearRing>
 										</gml:exterior>
 									</gml:Polygon>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 								</FlexibleArea>
@@ -224,7 +224,7 @@ The Calendar is shown coded as
 											</gml:LinearRing>
 										</gml:exterior>
 									</gml:Polygon>
-									<TransportMode> bus</TransportMode>
+									<TransportMode>bus</TransportMode>
 									<BoardingUse>true</BoardingUse>
 									<AlightingUse>true</AlightingUse>
 								</FlexibleArea>

--- a/examples/functions/variant/Netex_VariantExample_Step_05.xml
+++ b/examples/functions/variant/Netex_VariantExample_Step_05.xml
@@ -104,7 +104,7 @@ This is variant on the multistep SImple Network Version example on versioning.
 						<GeneralFrameMember modification="revise" id="mybus:GeneralFrameMember:ntwkf002_04" version="002">
 							<ServiceLinkRef version="001" ref="mybus:ServiceLink:SL_AtoB01"/>
 						</GeneralFrameMember>
-						<GeneralFrameMember modification="new " id="mybus:GeneralFrameMember:ntwkf002_06" version="002">
+						<GeneralFrameMember modification="new" id="mybus:GeneralFrameMember:ntwkf002_06" version="002">
 							<ServiceLinkRef version="001" ref="mybus:ServiceLink:SL_BtoC01"/>
 						</GeneralFrameMember>
 						<GeneralFrameMember id="mybus:GeneralFrameMember:ntwkf002_07" version="002">

--- a/examples/functions/versioning/Netex_VersioningExample_Step_05_ByRef.xml
+++ b/examples/functions/versioning/Netex_VersioningExample_Step_05_ByRef.xml
@@ -80,7 +80,7 @@ This version shows the use of thye general  frame to hold references rather than
 				<GeneralFrameMember id="mybus:ntwkf001_04" version="001">
 					<ServiceLinkRef ref="mybu:SL_AtoB01"/>
 				</GeneralFrameMember>
-				<GeneralFrameMember modification="new " id="mybus:ntwkf001_06" version="001">
+				<GeneralFrameMember modification="new" id="mybus:ntwkf001_06" version="001">
 					<ServiceLinkRef ref="mybu:SL_BtoC01"/>
 				</GeneralFrameMember>
 				<GeneralFrameMember id="mybus:ntwkf001_07" version="001">

--- a/examples/standards/gtfs/Netex_gtfs_exm1_Routes_1.xml
+++ b/examples/standards/gtfs/Netex_gtfs_exm1_Routes_1.xml
@@ -91,7 +91,7 @@ NeTEx (C) CEN Copyright 2010-2019
 				<Line version="any" id="mygtfsxm:BFC">
 					<Name>Bullfrog - Furnace Creek Resort</Name>
 					<Description/>
-					<TransportMode>bus </TransportMode>
+					<TransportMode>bus</TransportMode>
 					<Url>http://www.demoagency.org/bfc</Url>
 					<PublicCode>20</PublicCode>
 					<OperatorRef ref="mygtfsxm:Operator:DTA"/>

--- a/examples/standards/gtfs/Netex_gtfs_exm1_zz_Composite.xml
+++ b/examples/standards/gtfs/Netex_gtfs_exm1_zz_Composite.xml
@@ -388,7 +388,7 @@ version 1.1 with revised ids
 						<Line version="any" id="mygtfsxm:BFC">
 							<Name>Bullfrog - Furnace Creek Resort</Name>
 							<Description/>
-							<TransportMode>bus </TransportMode>
+							<TransportMode>bus</TransportMode>
 							<Url>http://www.demoagency.org/bfc</Url>
 							<PublicCode>20</PublicCode>
 							<AuthorityRef version="any" ref="mygtfsxm:DTA"/>

--- a/examples/standards/noptis/NeTEx_Calendar_TimetableAndVehicleSchedule_PB2.xml
+++ b/examples/standards/noptis/NeTEx_Calendar_TimetableAndVehicleSchedule_PB2.xml
@@ -175,7 +175,7 @@ is relevant for supplying an Integrator with partial data from multiple sources.
 								<JourneyAccounting version="any" id="noptis:9015002020100001">
 									<SupplyContractRef versionRef="EXTERNAL" ref="noptis:SL:264"/>
 									<AccountingCode>BB</AccountingCode>
-									<AccountingType> contract</AccountingType>
+									<AccountingType>contract</AccountingType>
 									<Distance>44496</Distance>
 									<Duration>PT89M</Duration>
 								</JourneyAccounting>
@@ -184,7 +184,7 @@ is relevant for supplying an Integrator with partial data from multiple sources.
 							<noticeAssignments>
 								<NoticeAssignmentView>
 									<NoticeRef ref="xxx"/>
-									<PublicityChannel> dynamicMedia</PublicityChannel>
+									<PublicityChannel>dynamicMedia</PublicityChannel>
 									<Advertised>true</Advertised>
 									<Text>Special conditions apply for payment.</Text>
 								</NoticeAssignmentView>
@@ -367,7 +367,7 @@ is relevant for supplying an Integrator with partial data from multiple sources.
 								<JourneyAccounting version="any" id="noptis:9015002020100003">
 									<SupplyContractRef versionRef="EXTERNAL" ref="noptis:SL:264"/>
 									<AccountingCode>BB</AccountingCode>
-									<AccountingType> contract</AccountingType>
+									<AccountingType>contract</AccountingType>
 									<Distance>44496</Distance>
 									<Duration>PT89M</Duration>
 								</JourneyAccounting>


### PR DESCRIPTION
While testing my parser for NeTEx I have found these enum values that contain extra spaces. Because of that the parser cannot parse the files.

Fixes: #1053