### PR TITLE
Fix misleading ParticipantRef documentation

### DIFF
--- a/xsd/NeTEx_publication-NoConstraint.xsd
+++ b/xsd/NeTEx_publication-NoConstraint.xsd
@@ -66,7 +66,7 @@ Roads and Road transport.
 	<!-- ======================================================================= -->
 	<xsd:element name="ParticipantRef" type="siri:ParticipantCodeType">
 		<xsd:annotation>
-			<xsd:documentation>Identifier of system requesting Data.</xsd:documentation>
+			<xsd:documentation>External code identifying the source of the data being exchanged.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="PublicationRequest" type="PublicationRequestStructure">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -251,7 +251,7 @@
 	<!-- ======================================================================= -->
 	<xsd:element name="ParticipantRef" type="siri:ParticipantCodeType">
 		<xsd:annotation>
-			<xsd:documentation>Identifier of system requesting Data.</xsd:documentation>
+			<xsd:documentation>External code identifying the source of the data being exchanged.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="PublicationRequest" type="PublicationRequestStructure">

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -102,7 +102,7 @@ Roads and Road transport.
 	<!-- ======================================================================= -->
 	<xsd:element name="ParticipantRef" type="siri:ParticipantCodeType">
 		<xsd:annotation>
-			<xsd:documentation>Identifier of system requesting Data.</xsd:documentation>
+			<xsd:documentation>External code identifying the source of the data being exchanged.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="PublicationRequest" type="PublicationRequestStructure">

--- a/xsd/wsdl/NeTEx_publication-NoConstraint.xsd
+++ b/xsd/wsdl/NeTEx_publication-NoConstraint.xsd
@@ -66,7 +66,7 @@ Roads and Road transport.
 	<!-- ======================================================================= -->
 	<xsd:element name="ParticipantRef" type="siri:ParticipantCodeType">
 		<xsd:annotation>
-			<xsd:documentation>Identifier of system requesting Data.</xsd:documentation>
+			<xsd:documentation>External code identifying the source of the data being exchanged.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="PublicationRequest" type="PublicationRequestStructure">


### PR DESCRIPTION
## Problem

The `ParticipantRef` element in the publication schemas is documented as
*"Identifier of system requesting Data."*

That wording only fits the request case. In a publication delivery the field
identifies the party that *produced* the data, not a requestor — so the
mandatory (delivery) use is documented incorrectly.

Additionally, the value is a **code** (NMTOKEN via `siri:ParticipantCodeType`),
not a reference to an object. There is no `Participant` type and no `keyref` —
the value *is* the identity. The `...Ref` name suggests an object reference that
does not exist.

## Fix

Short term (documentation only, non-breaking): update the `xsd:documentation`
to cover both publication and request:

> External code identifying the source of the data being exchanged.

Applied to all four top-level publication schemas:
- `xsd/NeTEx_publication.xsd`
- `xsd/NeTEx_publication_timetable.xsd`
- `xsd/NeTEx_publication-NoConstraint.xsd`
- `xsd/wsdl/NeTEx_publication-NoConstraint.xsd`

The element name and type are left unchanged, so there is no schema break.
