### PR TITLE
Fix spelling typos in xsd:documentation

### DIFF
--- a/xsd/NeTEx_publication-NoConstraint.xsd
+++ b/xsd/NeTEx_publication-NoConstraint.xsd
@@ -88,13 +88,13 @@ Roads and Road transport.
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 			<xsd:element name="topics" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>One or more Request filters that specify tthe data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
+					<xsd:documentation>One or more Request filters that specify the data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>
 						<xsd:element name="NetworkFrameTopic" type="NetworkFrameTopicStructure" maxOccurs="unbounded">
 							<xsd:annotation>
-								<xsd:documentation>Vaues to use select Network Objects.</xsd:documentation>
+								<xsd:documentation>Values to use select Network Objects.</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:sequence>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -273,13 +273,13 @@
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 			<xsd:element name="topics" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>One or more Request filters that specify tthe data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
+					<xsd:documentation>One or more Request filters that specify the data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>
 						<xsd:element name="NetworkFrameTopic" type="NetworkFrameTopicStructure" maxOccurs="unbounded">
 							<xsd:annotation>
-								<xsd:documentation>Vaues to use select Network Objects.</xsd:documentation>
+								<xsd:documentation>Values to use select Network Objects.</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:sequence>

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -124,13 +124,13 @@ Roads and Road transport.
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 			<xsd:element name="topics" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>One or more Request filters that specify tthe data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
+					<xsd:documentation>One or more Request filters that specify the data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>
 						<xsd:element name="NetworkFrameTopic" type="NetworkFrameTopicStructure" maxOccurs="unbounded">
 							<xsd:annotation>
-								<xsd:documentation>Vaues to use select Network Objects.</xsd:documentation>
+								<xsd:documentation>Values to use select Network Objects.</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:sequence>

--- a/xsd/netex_framework/netex_frames/netex_generalFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_generalFrame_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:complexType name="entityInVersionInFrame_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for an ENTITIY IN VERSION IN FRAME member.</xsd:documentation>
+			<xsd:documentation>Type for an ENTITY IN VERSION IN FRAME member.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">

--- a/xsd/netex_framework/netex_genericFramework/netex_grouping_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_grouping_version.xsd
@@ -324,7 +324,7 @@ Rail transport, Roads and Road transport
 				<xsd:sequence>
 					<xsd:element name="PurposeOfGroupingRef" type="PurposeOfGroupingRefStructure" minOccurs="0">
 						<xsd:annotation>
-							<xsd:documentation>Reference to a PUPOSE OF GROUPING to which this member belongs. If given by context does not need to be specified.</xsd:documentation>
+							<xsd:documentation>Reference to a PURPOSE OF GROUPING to which this member belongs. If given by context does not need to be specified.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="MemberClassRef" type="ClassRefStructure">

--- a/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
@@ -1067,7 +1067,7 @@ Rail transport, Roads and Road transport
 				<xsd:sequence>
 					<xsd:group ref="ContactGroup">
 						<xsd:annotation>
-							<xsd:documentation>Details for resuable CONTACT.</xsd:documentation>
+							<xsd:documentation>Details for reusable CONTACT.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:group>
 				</xsd:sequence>

--- a/xsd/netex_framework/netex_genericFramework/netex_path_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_path_version.xsd
@@ -112,7 +112,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="GenericPathLinkDurationGroup">
 		<xsd:annotation>
-			<xsd:documentation>Duration properties of a GENERIC PATH LINK. NB Cant be move up to on PATH LINK without breakage. revise in V3.0</xsd:documentation>
+			<xsd:documentation>Duration properties of a GENERIC PATH LINK. NB Can't be move up to on PATH LINK without breakage. revise in V3.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="TransferDuration" type="TransferDurationStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
@@ -133,7 +133,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="GeneralSection" substitutionGroup="Section_Dummy">
 		<xsd:annotation>
-			<xsd:documentation>A resuable sequence of LINKS or POINTs. +v1.1.</xsd:documentation>
+			<xsd:documentation>A reusable sequence of LINKS or POINTs. +v1.1.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_responsibility/netex_dataSource_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_dataSource_version.xsd
@@ -179,7 +179,7 @@ References to a DATA SOURCE are useful in an interoperated computer system.</xsd
 						<xsd:sequence>
 							<xsd:element name="Presentation" type="PresentationStructure" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Preferred presentation values assoicated with BRANDING. +v1.1</xsd:documentation>
+									<xsd:documentation>Preferred presentation values associated with BRANDING. +v1.1</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:sequence>

--- a/xsd/netex_framework/netex_responsibility/netex_relationship.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_relationship.xsd
@@ -63,7 +63,7 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="all">
 				<xsd:annotation>
-					<xsd:documentation>This incldues definitions of one ore more new entities.</xsd:documentation>
+					<xsd:documentation>This includes definitions of one or more new entities.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="changesOnly">

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_version.xsd
@@ -99,7 +99,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="privateCodes" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>A list of private codes that uniquely identifiy the element. May be used for inter-operating with other (legacy) systems. +v2.0</xsd:documentation>
+					<xsd:documentation>A list of private codes that uniquely identify the element. May be used for inter-operating with other (legacy) systems. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>
@@ -226,7 +226,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="privateCodes" type="PrivateCodesStructure">
 		<xsd:annotation>
-			<xsd:documentation>A list of private codes that uniquely identifiy the element. May be used for inter-operating with other (legacy) systems. +v2.0</xsd:documentation>
+			<xsd:documentation>A list of private codes that uniquely identify the element. May be used for inter-operating with other (legacy) systems. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:unique name="PrivateCodeType">
 			<xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_versionFrame_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_versionFrame_version.xsd
@@ -385,7 +385,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:complexType name="classesInRepository_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of Classe Filter referencess.</xsd:documentation>
+			<xsd:documentation>Type for a list of Class Filter referencess.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">

--- a/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_support.xsd
@@ -49,7 +49,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEX: AVALABILITY CONDITION identifier types.</xsd:documentation>
+		<xsd:documentation>NeTEX: AVAILABILITY CONDITION identifier types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_version.xsd
@@ -51,7 +51,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEX: AVALABILITY CONDITION types.</xsd:documentation>
+		<xsd:documentation>NeTEX: AVAILABILITY CONDITION types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<xsd:complexType name="availabilityConditions_RelStructure">

--- a/xsd/netex_framework/netex_reusableComponents/netex_country_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_country_support.xsd
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="cf">
 				<xsd:annotation>
-					<xsd:documentation>CEN tral African Republic.</xsd:documentation>
+					<xsd:documentation>Central African Republic.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="cg">

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPath_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPath_version.xsd
@@ -70,7 +70,7 @@ Rail transport, Roads and Road transport
 	<!-- ============================================== -->
 	<xsd:group name="DeckPathGroup">
 		<xsd:annotation>
-			<xsd:documentation>Deck Path elemenst fro DECK</xsd:documentation>
+			<xsd:documentation>Deck Path elements from DECK</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="deckPathJunctions" type="deckPathJunctionRefs_RelStructure" minOccurs="0">
@@ -499,7 +499,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:group name="DeckElementPropertiesGroup">
 		<xsd:annotation>
-			<xsd:documentation>Detailed properties of a DECK ELEMENT, these are simialr to properties of a SITE ELEMENT.</xsd:documentation>
+			<xsd:documentation>Detailed properties of a DECK ELEMENT, these are similar to properties of a SITE ELEMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:group ref="EnvironmentPropertiesGroup"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -294,7 +294,7 @@
 			<xsd:element ref="ClassOfUseRef" minOccurs="0"/>
 			<xsd:element name="FareClass" type="FareClassEnumeration" default="any" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Edit care class for which capacity is specifyed. Default is any, i.e. capacity is for all classes.</xsd:documentation>
+					<xsd:documentation>Edit care class for which capacity is specified. Default is any, i.e. capacity is for all classes.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="AccessibilityAssessment" minOccurs="0"/>
@@ -752,7 +752,7 @@
 	</xsd:group>
 	<xsd:group name="DeckEntranceClassificationGroup">
 		<xsd:annotation>
-			<xsd:documentation>EClassification lements for a DECK ENTRANCE.</xsd:documentation>
+			<xsd:documentation>Classification elements for a DECK ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="DeckEntranceType" type="DeckEntranceTypeEnumeration" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_environment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_environment_support.xsd
@@ -126,7 +126,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="TiltType" type="TiltTypeEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Coded value of the maximum tilt. See allowed va;ues. +v1.1</xsd:documentation>
+					<xsd:documentation>Coded value of the maximum tilt. See allowed values. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
@@ -632,7 +632,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Name of Accomodation _v1.1</xsd:documentation>
+					<xsd:documentation>Name of Accommodation _v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="ServiceFacilitySetRef" minOccurs="0"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="SecurityListsInFrameGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elemens for SECURITY LISTs in Frame.</xsd:documentation>
+			<xsd:documentation>Elements for SECURITY LISTs in Frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="blacklists" type="blacklistsInFrame_RelStructure" minOccurs="0">
@@ -192,7 +192,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="SecurityListing_Dummy" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
 		<xsd:annotation>
-			<xsd:documentation>DUMMY type for SECIRITY LISTING.</xsd:documentation>
+			<xsd:documentation>DUMMY type for SECURITY LISTING.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="SecurityListing" abstract="true" substitutionGroup="SecurityListing_Dummy">

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_version.xsd
@@ -618,7 +618,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TimebandRef" minOccurs="0" maxOccurs="5"/>
 			<xsd:element name="isAvailable" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether availabel on assigned day</xsd:documentation>
+					<xsd:documentation>Whether available on assigned day</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -381,7 +381,7 @@
 			</xsd:element>
 			<xsd:element name="HeadroomForLuggage" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Height avilable for LUGGAGE</xsd:documentation>
+					<xsd:documentation>Height available for LUGGAGE</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="IsLockable" type="xsd:boolean" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="CountryRef" minOccurs="0"/>
 			<xsd:element name="otherCountries" type="countryRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>For TOPOGRAPHIC PLACEs that's span borders, references to additional COUNTRY or COUNTRIEs that place lies in.</xsd:documentation>
+					<xsd:documentation>For TOPOGRAPHIC PLACEs that span borders, references to additional COUNTRY or COUNTRIEs that place lies in.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ParentTopographicPlaceRef" type="TopographicPlaceRefStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="CountryRef" minOccurs="0"/>
 			<xsd:element name="otherCountries" type="countryRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>For TOPOGRAPHIC PLACEs thats span borders, references to additional COUNTRY or COUNTRIEs that place lies in.</xsd:documentation>
+					<xsd:documentation>For TOPOGRAPHIC PLACEs that's span borders, references to additional COUNTRY or COUNTRIEs that place lies in.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ParentTopographicPlaceRef" type="TopographicPlaceRefStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
@@ -323,7 +323,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:element name="TrainElement" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation> According to Transmodel 6.2 This shoud really be called TRAIN ELEMENT TYPE and be abstract . Use as concrete element DEPRECATED - use more specific TRAILING ELEMENT TYPE or TRACTIVE ELEMENT TYPE subtypes, Shoul dbe renmaed and removed in V3.0</xsd:documentation>
+			<xsd:documentation> According to Transmodel 6.2 This should really be called TRAIN ELEMENT TYPE and be abstract . Use as concrete element DEPRECATED - use more specific TRAILING ELEMENT TYPE or TRACTIVE ELEMENT TYPE subtypes, Should dbe renmaed and removed in V3.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
@@ -323,7 +323,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:element name="TrainElement" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation> According to Transmodel 6.2 This should really be called TRAIN ELEMENT TYPE and be abstract . Use as concrete element DEPRECATED - use more specific TRAILING ELEMENT TYPE or TRACTIVE ELEMENT TYPE subtypes, Should dbe renmaed and removed in V3.0</xsd:documentation>
+			<xsd:documentation> According to Transmodel 6.2 This should really be called TRAIN ELEMENT TYPE and be abstract . Use as concrete element DEPRECATED - use more specific TRAILING ELEMENT TYPE or TRACTIVE ELEMENT TYPE subtypes, Should be renamed and removed in V3.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
@@ -496,7 +496,7 @@ Rail transport, Roads and Road transport
 	<!-- ======= FACILITY REQUIREMENT =================================================== -->
 	<xsd:simpleType name="FacilityRequirementIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a FACILITY REQUIRMENT.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a FACILITY REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="VehicleRequirementIdType"/>
 	</xsd:simpleType>
@@ -507,7 +507,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="FacilityRequirementRefStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a reference to a FACILITY REQUIRMENT.</xsd:documentation>
+			<xsd:documentation>Type for a reference to a FACILITY REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:restriction base="VehicleRequirementRefStructure">

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -497,7 +497,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MinimumAge" type="xsd:nonNegativeInteger" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Minumum age to use TRANSPORT TYPE.</xsd:documentation>
+					<xsd:documentation>Minimum age to use TRANSPORT TYPE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Portable" type="xsd:boolean" minOccurs="0">
@@ -742,7 +742,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="FareClass" type="FareClassEnumeration" default="any" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Fare class for which capacity is specifyed. Default is any, i.e. capacity is for all FARE CLASSes.</xsd:documentation>
+					<xsd:documentation>Fare class for which capacity is specified. Default is any, i.e. capacity is for all FARE CLASSes.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="CapacityGroup"/>
@@ -1146,7 +1146,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="equipmentProfiles" type="vehicleEquipmentProfileRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Equipment profiles assoicated with model. +v1.2.2</xsd:documentation>
+					<xsd:documentation>Equipment profiles associated with model. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="VehicleModelProfileRef" minOccurs="0"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicle_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicle_version.xsd
@@ -311,7 +311,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="RollingStockType" type="TrainElementTypeTypeEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Fixed classication of ROLLING STOCK ITEM.</xsd:documentation>
+					<xsd:documentation>Fixed classification of ROLLING STOCK ITEM.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfRollingStockRef" minOccurs="0"/>

--- a/xsd/netex_framework/netex_utility/netex_utility_types.xsd
+++ b/xsd/netex_framework/netex_utility/netex_utility_types.xsd
@@ -474,7 +474,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="xsd:anyURI">
 				<xsd:attribute name="typeOfInfoLink">
 					<xsd:annotation>
-						<xsd:documentation>Functional classifcation of an info link.</xsd:documentation>
+						<xsd:documentation>Functional classification of an info link.</xsd:documentation>
 					</xsd:annotation>
 					<xsd:simpleType>
 						<xsd:list itemType="TypeOfInfoLinkEnumeration"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_support.xsd
@@ -931,7 +931,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="StepConditionEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values forthe Step Condition</xsd:documentation>
+			<xsd:documentation>Allowed values for the Step Condition</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="even">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1284,7 +1284,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="EntrancePropertiesGroup">
 		<xsd:annotation>
-			<xsd:documentation>Property lements for ENTRANCE EQUIPMENT type.</xsd:documentation>
+			<xsd:documentation>Property elements for ENTRANCE EQUIPMENT type.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="Door" type="xsd:boolean" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentPassenger_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentPassenger_version.xsd
@@ -246,7 +246,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="ChangeAvailable" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether chaneg is available. +v1.1</xsd:documentation>
+					<xsd:documentation>Whether change is available. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -442,7 +442,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="PassengerBeaconEquipment" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
-			<xsd:documentation>Specialisation of PASSENGER EQUIPMENT for Beacons. For SSID or UUID always use PublicCode. Be aware that when using VEHICLE TYPE or VEHICLE PROFILE only the type of the beacon can be described. The information aboutn the relevent real beacon often can only be provided when the actual VEHICLE is known.</xsd:documentation>
+			<xsd:documentation>Specialisation of PASSENGER EQUIPMENT for Beacons. For SSID or UUID always use PublicCode. Be aware that when using VEHICLE TYPE or VEHICLE PROFILE only the type of the beacon can be described. The information aboutn the relevant real beacon often can only be provided when the actual VEHICLE is known.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentPassenger_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentPassenger_version.xsd
@@ -442,7 +442,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="PassengerBeaconEquipment" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
-			<xsd:documentation>Specialisation of PASSENGER EQUIPMENT for Beacons. For SSID or UUID always use PublicCode. Be aware that when using VEHICLE TYPE or VEHICLE PROFILE only the type of the beacon can be described. The information aboutn the relevant real beacon often can only be provided when the actual VEHICLE is known.</xsd:documentation>
+			<xsd:documentation>Specialisation of PASSENGER EQUIPMENT for Beacons. For SSID or UUID always use PublicCode. Be aware that when using VEHICLE TYPE or VEHICLE PROFILE only the type of the beacon can be described. The information about the relevant real beacon often can only be provided when the actual VEHICLE is known.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_localService_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_localService_version.xsd
@@ -579,7 +579,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element name="PropertyKeptForDuration" type="xsd:duration" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Period for which lost property is kept - after this tiome it may be disposed of. +v1.1</xsd:documentation>
+									<xsd:documentation>Period for which lost property is kept - after this time it may be disposed of. +v1.1</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:sequence>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
@@ -943,7 +943,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="NumberOfBaysWithRecharging" type="xsd:nonNegativeInteger" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Total number of parking places supportig Electric car recharging in PARKING AREA.</xsd:documentation>
+					<xsd:documentation>Total number of parking places supporting Electric car recharging in PARKING AREA.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
@@ -368,7 +368,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="PaymentAppDownloadUrl" type="xsd:anyURI" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>URL to downlaod app to pay.</xsd:documentation>
+					<xsd:documentation>URL to download app to pay.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -763,7 +763,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="NumberOfSpacesWithRechargePoint" type="NumberOfVehicles" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Number of parking places with eletric chargepoints.</xsd:documentation>
+					<xsd:documentation>Number of parking places with electric chargepoints.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -943,7 +943,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="NumberOfBaysWithRecharging" type="xsd:nonNegativeInteger" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Total number of parking places supportig Electirc car recharging in PARKING AREA.</xsd:documentation>
+					<xsd:documentation>Total number of parking places supportig Electric car recharging in PARKING AREA.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_support.xsd
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="PathJunctionRef" type="SitePathJunctionRefStructure" substitutionGroup="GenericPathJunctionRef">
 		<xsd:annotation>
-			<xsd:documentation>Depreceated - use SitePathJunctionRef +v2.0</xsd:documentation>
+			<xsd:documentation>Deprecated - use SitePathJunctionRef +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!-- ====== SITE PATH JUNCTION  =========================================================== -->

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_version.xsd
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 				<xsd:element ref="SiteElementRef"/>
 				<xsd:element name="PlaceRef" type="PlaceRefStructure">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED: Reference to a PLACE, including QUAY, ACCESS SPACE, BOARDING POSITION or other node of a SITE. Use more specifc SITE COMPONENT. -v2.0</xsd:documentation>
+						<xsd:documentation>DEPRECATED: Reference to a PLACE, including QUAY, ACCESS SPACE, BOARDING POSITION or other node of a SITE. Use more specific SITE COMPONENT. -v2.0</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -74,7 +74,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="SiteElement" type="SiteElement_VersionStructure" abstract="true" substitutionGroup="Place">
 		<xsd:annotation>
-			<xsd:documentation>A physical PLACE to which passengers may go. May have ACCESSIBILITY ASSESMENT and other properties to describe it.</xsd:documentation>
+			<xsd:documentation>A physical PLACE to which passengers may go. May have ACCESSIBILITY ASSESSMENT and other properties to describe it.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="SiteElement_VersionStructure" abstract="true">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -1311,7 +1311,7 @@ contained within its parent QUAY.</xsd:documentation>
 	<!-- ======================================================================= -->
 	<xsd:complexType name="vehiclePositionAlignments_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of VEHICLE POSTION ALIGNMENTs.</xsd:documentation>
+			<xsd:documentation>Type for a list of VEHICLE POSITION ALIGNMENTs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
@@ -1345,7 +1345,7 @@ contained within its parent QUAY.</xsd:documentation>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="VehiclePositionAlignmentIdType" use="required">
 						<xsd:annotation>
-							<xsd:documentation>Identifier of VEHICLE POSTION ALIGNMENT.</xsd:documentation>
+							<xsd:documentation>Identifier of VEHICLE POSITION ALIGNMENT.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:restriction>
@@ -1354,7 +1354,7 @@ contained within its parent QUAY.</xsd:documentation>
 	</xsd:element>
 	<xsd:complexType name="VehiclePositionAlignment_VersionStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a VEHICLE POSTION ALIGNMENT.</xsd:documentation>
+			<xsd:documentation>Type for a VEHICLE POSITION ALIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="VersionedChildStructure">
@@ -1371,7 +1371,7 @@ contained within its parent QUAY.</xsd:documentation>
 	</xsd:complexType>
 	<xsd:group name="VehiclePositionAlignmentGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements of a VEHICLE POSTION ALIGNMENT.</xsd:documentation>
+			<xsd:documentation>Elements of a VEHICLE POSITION ALIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="VehicleStoppingPositionRef" minOccurs="0"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_rechargingPointAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_rechargingPointAssignment_version.xsd
@@ -77,7 +77,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:complexType name="rechargingPointAssignments_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a lsit of RECHARGING POINT ASSIGNMENTs.</xsd:documentation>
+			<xsd:documentation>Type for a list of RECHARGING POINT ASSIGNMENTs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
@@ -208,7 +208,7 @@ Rail transport, Roads and Road transport
 	<!-- =========== RECHARGING BAY  ============================================== -->
 	<xsd:complexType name="rechargingBays_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a lsit of RECHARGING BAYs.</xsd:documentation>
+			<xsd:documentation>Type for a list of RECHARGING BAYs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_support.xsd
@@ -436,7 +436,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="DestinationDisplayContextEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values forr Destination Display Context. +v1.1.</xsd:documentation>
+			<xsd:documentation>Allowed values for Destination Display Context. +v1.1.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="any"/>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -113,7 +113,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="Network" minOccurs="0"/>
 			<xsd:element name="additionalNetworks" type="networksInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Additional networks refernced in frame in addition to the primary NETWORK..</xsd:documentation>
+					<xsd:documentation>Additional networks referenced in frame in addition to the primary NETWORK..</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -666,7 +666,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="DestinationDisplayCodeGroup"/>
 			<xsd:element name="Presentation" type="PresentationStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Preferred presentation attributes to use when rendering destiation on maps, etc. +v1.1</xsd:documentation>
+					<xsd:documentation>Preferred presentation attributes to use when rendering destination on maps, etc. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="vias" type="vias_RelStructure" minOccurs="0">
@@ -676,7 +676,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="variants" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DESTINATION DISPLAY VARIANT for DESTINATION DISPLAY. Variants may be for use in a specifc context or on a specifc media, or a combination of both.</xsd:documentation>
+					<xsd:documentation>DESTINATION DISPLAY VARIANT for DESTINATION DISPLAY. Variants may be for use in a specific context or on a specific media, or a combination of both.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:complexContent>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_support.xsd
@@ -57,7 +57,7 @@ Rail transport, Roads and ROAD transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEX: NETWORK INFRASTUCTURE identifier Types.</xsd:documentation>
+		<xsd:documentation>NeTEX: NETWORK INFRASTRUCTURE identifier Types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="InfrastructurePointIdType">

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
@@ -57,7 +57,7 @@ Rail transport, Roads and ROAD transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEX: NETWORK INFRASTUCTURE Types.</xsd:documentation>
+		<xsd:documentation>NeTEX: NETWORK INFRASTRUCTURE Types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
@@ -98,7 +98,7 @@ Rail transport, Roads and ROAD transport
 	<!-- ===NETWORK RESTRICTIONs================================================= -->
 	<xsd:element name="NetworkRestriction" type="NetworkRestriction_VersionStructure" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
-			<xsd:documentation>A constraint on use of a network of INFRASTRUCTURE POINTs and INFRASTUCTURE LINKs.</xsd:documentation>
+			<xsd:documentation>A constraint on use of a network of INFRASTRUCTURE POINTs and INFRASTRUCTURE LINKs.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="NetworkRestriction_VersionStructure" abstract="true">

--- a/xsd/netex_part_1/part1_networkDescription/netex_vehicleAndCrewPoint_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_vehicleAndCrewPoint_version.xsd
@@ -402,7 +402,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="operators" type="transportOrganisationRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>OPERATORs assoicated with GARAGE.</xsd:documentation>
+					<xsd:documentation>OPERATORs associated with GARAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="garagePoints" type="garagePoints_RelStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_version.xsd
@@ -329,7 +329,7 @@ Rail transport, Roads and Road transport
 							<xsd:element ref="ScheduledStopPointView" minOccurs="0"/>
 							<xsd:element name="AbridgementRanking" type="xsd:integer" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Relative ranking for omitting this FARE POINT IN JOURNEY PATTERN when presenting an abridged verson of the series as an itinerary. 1=High, i.e. omit first.</xsd:documentation>
+									<xsd:documentation>Relative ranking for omitting this FARE POINT IN JOURNEY PATTERN when presenting an abridged version of the series as an itinerary. 1=High, i.e. omit first.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element name="PresentationPosition" type="SeriesPresentationEnumeration" minOccurs="0">
@@ -378,7 +378,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="ScheduledStopPointView" minOccurs="0"/>
 			<xsd:element name="AbridgementRanking" type="xsd:integer" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Relative ranking for omitting this FARE POINT IN JOURNEY PATTERN when presenting an abridged verson of the series. 1=High.- omit first.</xsd:documentation>
+					<xsd:documentation>Relative ranking for omitting this FARE POINT IN JOURNEY PATTERN when presenting an abridged version of the series. 1=High.- omit first.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="PresentationPosition" type="SeriesPresentationEnumeration" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_support.xsd
@@ -57,7 +57,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx: JOURNEY PATTERN identfier types.</xsd:documentation>
+		<xsd:documentation>NeTEx: JOURNEY PATTERN identifier types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ===JOURNEY PATTERN====================================================== -->
 	<xsd:complexType name="journeyPatternRefs_RelStructure">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="NameSuffix" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Optional l Suffix for Name of SCHEDULED STOP POINT.</xsd:documentation>
+					<xsd:documentation>Optional Suffix for Name of SCHEDULED STOP POINT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="NameSuffix" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Optiona l Suffix for Name of SCHEDULED STOP POINT.</xsd:documentation>
+					<xsd:documentation>Optional l Suffix for Name of SCHEDULED STOP POINT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
@@ -324,7 +324,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="ExternalStopPointRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>An alternative code that uniquely identifies the STOP POINT. pecifically for use in AVMS systems that require an alias, if. For VDV compatibility. DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
+					<xsd:documentation>An alternative code that uniquely identifies the STOP POINT. specifically for use in AVMS systems that require an alias, if. For VDV compatibility. DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -611,7 +611,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="VehicleMeetingPointRef" type="PointRefStructure" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>VEHICLE MEETING POINT at END OF CONENCTION. +V1.2.2. NB This is typed only to POINT to avoid forward dependency</xsd:documentation>
+						<xsd:documentation>VEHICLE MEETING POINT at END OF CONNECTION. +V1.2.2. NB This is typed only to POINT to avoid forward dependency</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_siteConnection_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_siteConnection_version.xsd
@@ -152,7 +152,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="VehicleMeetingPointRef" type="PointRefStructure" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>VEHICLE MEETING POINT at END OF CONENCTION. +V1.2.2. NB This is typed only to POINT to avoid forward dependency</xsd:documentation>
+						<xsd:documentation>VEHICLE MEETING POINT at END OF CONNECTION. +V1.2.2. NB This is typed only to POINT to avoid forward dependency</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -224,7 +224,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="PassengerStopAssignmentGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for a PASSENGER STOP ASSIGNMENT. Either StopPlace(Ref) or Quay(Ref) must at least be present. Best practice is to always have at least the StopPlace(Ref). It is also prefered that the Ref are used and the Quay/StopPlace are defined on their own in the appropriate Frame.</xsd:documentation>
+			<xsd:documentation>Elements for a PASSENGER STOP ASSIGNMENT. Either StopPlace(Ref) or Quay(Ref) must at least be present. Best practice is to always have at least the StopPlace(Ref). It is also preferred that the Ref are used and the Quay/StopPlace are defined on their own in the appropriate Frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:choice minOccurs="0">
@@ -353,7 +353,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="IsAllowed" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether assigment permits or forbids any use of TRAIN COMPONENT at specifed stop. Default is true. +V2.0</xsd:documentation>
+					<xsd:documentation>Whether assignment permits or forbids any use of TRAIN COMPONENT at specified stop. Default is true. +V2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="EntranceToVehicle" type="MultilingualString" minOccurs="0">

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
@@ -194,7 +194,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="groupsOfServices" type="groupsOfServicesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Groupings of Journeys In frame. Can be used to define inbound and outbound beds for a matrix presentation of the JORUNEYs in the TIMETABLE.</xsd:documentation>
+					<xsd:documentation>Groupings of Journeys In frame. Can be used to define inbound and outbound beds for a matrix presentation of the JOURNEYs in the TIMETABLE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="trainNumbers" type="trainNumbersInFrame_RelStructure" minOccurs="0">

--- a/xsd/netex_part_2/part2_frames/netex_vehicleScheduleFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_vehicleScheduleFrame_version.xsd
@@ -61,7 +61,7 @@
 		<xsd:sequence>
 			<xsd:element name="VehicleModes" type="AllPublicTransportModesListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>PUBLIC TRANPORT MODEs of VEHICLE SCHEDULE.</xsd:documentation>
+					<xsd:documentation>PUBLIC TRANSPORT MODEs of VEHICLE SCHEDULE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -227,7 +227,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="DriverRef" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround ! -v2.0</xsd:documentation>
+					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way around ! -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -324,7 +324,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 					</xsd:sequence>
 					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="required">
 						<xsd:annotation>
-							<xsd:documentation>Identifier of NORMAL DATED VEHICLE JORUNEY.</xsd:documentation>
+							<xsd:documentation>Identifier of NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:restriction>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -263,7 +263,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="ConnectingStopPointName" type="MultilingualString" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Name of CONNETCING STOP POINT.</xsd:documentation>
+					<xsd:documentation>Name of CONNECTING STOP POINT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice>
@@ -563,7 +563,7 @@ Default is false.</xsd:documentation>
 			</xsd:element>
 			<xsd:element name="ConnectionCertainty" type="ConnectionCertaintyEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Nature of gurantee to conenction.</xsd:documentation>
+					<xsd:documentation>Nature of guarantee to connection.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
@@ -629,12 +629,12 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		<xsd:sequence>
 			<xsd:element name="Origin" type="DeadRunEndpointStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Origin for DEAD RUN. Can be Derived from JORUNEY PATTERN.</xsd:documentation>
+					<xsd:documentation>Origin for DEAD RUN. Can be Derived from JOURNEY PATTERN.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Destination" type="DeadRunEndpointStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Destination for DEAD RUN. Can be derived from JORUNEY PATTERN.</xsd:documentation>
+					<xsd:documentation>Destination for DEAD RUN. Can be derived from JOURNEY PATTERN.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_vehicleService/netex_duty_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_duty_version.xsd
@@ -239,7 +239,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="AccountingTime" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>How long a time shoudl be used for the the ACCOUNTABLE ELEMENT.</xsd:documentation>
+					<xsd:documentation>How long a time should be used for the the ACCOUNTABLE ELEMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AccountingFactor" type="xsd:decimal" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -866,7 +866,7 @@ Rail transport, Roads and Road transport
 		<xsd:choice>
 			<xsd:element name="validityParameterAssignments" type="genericParameterAssignments_RelStructure">
 				<xsd:annotation>
-					<xsd:documentation>VALIDITY PARAMETER ASSIGNMENTss for an element.</xsd:documentation>
+					<xsd:documentation>VALIDITY PARAMETER ASSIGNMENTs for an element.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="GenericParameterAssignment">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -288,7 +288,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="IsAllowed" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether values are allowed ro forbiden. Defaullt is allowed.</xsd:documentation>
+					<xsd:documentation>Whether values are allowed ro forbidden. Default is allowed.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfAccessRightAssignmentRef" minOccurs="0"/>
@@ -346,7 +346,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="ValidityParameterAssignmentType" type="RelativeOperatorEnumeration" default="EQ" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Comparison Operator for comparing Validity Erlements valeus. Defalut is EQ.</xsd:documentation>
+					<xsd:documentation>Comparison Operator for comparing Validity Erlements values. Default is EQ.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ValidityParameterGroupingType" type="LogicalOperationEnumeration" default="AND" minOccurs="0">
@@ -452,7 +452,7 @@ Rail transport, Roads and Road transport
 			<xsd:choice>
 				<xsd:element name="VehicleModes" type="AllPublicTransportModesListOfEnumerations" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>PUBLIC TRANPORT MODEs to which ACCESS RIGHTs apply. DEPRECATED - keep for backwards compatibility. -v1.2.2</xsd:documentation>
+						<xsd:documentation>PUBLIC TRANSPORT MODEs to which ACCESS RIGHTs apply. DEPRECATED - keep for backwards compatibility. -v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="TransportModes" type="AllModesListOfEnumerations" minOccurs="0">
@@ -866,7 +866,7 @@ Rail transport, Roads and Road transport
 		<xsd:choice>
 			<xsd:element name="validityParameterAssignments" type="genericParameterAssignments_RelStructure">
 				<xsd:annotation>
-					<xsd:documentation>VALIDITY PARAMETR ASSIGNMENTss for an element.</xsd:documentation>
+					<xsd:documentation>VALIDITY PARAMETER ASSIGNMENTss for an element.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="GenericParameterAssignment">
@@ -964,7 +964,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="includes" type="genericParameterAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Assignments Logically included in this group. Groups are combined acording to the Operator.</xsd:documentation>
+					<xsd:documentation>Assignments Logically included in this group. Groups are combined according to the Operator.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -288,7 +288,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="IsAllowed" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether values are allowed ro forbidden. Default is allowed.</xsd:documentation>
+					<xsd:documentation>Whether values are allowed or forbidden. Default is allowed.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfAccessRightAssignmentRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -346,7 +346,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="ValidityParameterAssignmentType" type="RelativeOperatorEnumeration" default="EQ" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Comparison Operator for comparing Validity Erlements values. Default is EQ.</xsd:documentation>
+					<xsd:documentation>Comparison Operator for comparing Validity Elements values. Default is EQ.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ValidityParameterGroupingType" type="LogicalOperationEnumeration" default="AND" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_support.xsd
@@ -55,7 +55,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx: PRICING PARAMATER SET identifier types.</xsd:documentation>
+		<xsd:documentation>NeTEx: PRICING PARAMETER SET identifier types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- === PRICING PARAMETERS =================================================== -->

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -498,7 +498,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="PricingRule_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>Dumm abstract type of Pricing rule.</xsd:documentation>
+			<xsd:documentation>Dummy abstract type of Pricing rule.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="PricingRule" substitutionGroup="PricingRule_Dummy">

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -126,7 +126,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="PriceUnitRef" minOccurs="0"/>
 			<xsd:element name="priceUnits" type="priceUnits_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Set of Rounding paraemeters.</xsd:documentation>
+					<xsd:documentation>Set of Rounding parameters.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="pricingRules" type="pricingRules_RelStructure" minOccurs="0">
@@ -142,7 +142,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="RoundingRef" minOccurs="0"/>
 			<xsd:element name="roundings" type="roundings_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Set of Rounding paraemeters.</xsd:documentation>
+					<xsd:documentation>Set of Rounding parameters.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="DayTypeRef" minOccurs="0"/>
@@ -306,7 +306,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="RoundingStep">
 		<xsd:annotation>
-			<xsd:documentation>A rounding step to use to round a range of values. Any value larger than the step key and smaller tha the next step key should be rounded to this value.</xsd:documentation>
+			<xsd:documentation>A rounding step to use to round a range of values. Any value larger than the step key and smaller than the next step key should be rounded to this value.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -412,7 +412,7 @@ Rail transport, Roads and Road transport
 	<!-- === MONTH VALIDITY OFFSET================================================= -->
 	<xsd:complexType name="monthValidityOffsets_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Ser of MONTH VALIDITY OFFSETs parameters such as rounding steps for Frame.</xsd:documentation>
+			<xsd:documentation>Set of MONTH VALIDITY OFFSETs parameters such as rounding steps for Frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="strictContainmentAggregationStructure">
@@ -486,7 +486,7 @@ Rail transport, Roads and Road transport
 	<!-- === PRICING RULE ================================================= -->
 	<xsd:complexType name="pricingRules_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Ser of PRICING RULEs such for Frame.</xsd:documentation>
+			<xsd:documentation>Set of PRICING RULEs such for Frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
@@ -498,7 +498,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="PricingRule_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>Dumm abstact type of Pricing rule.</xsd:documentation>
+			<xsd:documentation>Dumm abstract type of Pricing rule.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="PricingRule" substitutionGroup="PricingRule_Dummy">
@@ -575,7 +575,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="PriceUnitRef" minOccurs="0"/>
 			<xsd:element name="url" type="xsd:anyURI" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>URLor rule. with infor fmethod to use.</xsd:documentation>
+					<xsd:documentation>URLor rule. with info fmethod to use.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -712,7 +712,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MinimumPriceAsPercentage" type="xsd:decimal" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Minumum price as percentage of whole price.</xsd:documentation>
+					<xsd:documentation>Minimum price as percentage of whole price.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MinimumPriceAsMultiple" type="xsd:integer" minOccurs="0">
@@ -727,7 +727,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MaximumPriceAsPercentage" type="xsd:decimal" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maxumum price as percentage of whole price.</xsd:documentation>
+					<xsd:documentation>Maximum price as percentage of whole price.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MaximumPriceAsMultiple" type="xsd:integer" minOccurs="0">
@@ -754,7 +754,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MaximumLimitPriceAsPercentage" type="xsd:decimal" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maxumum Limit as percentage of whole price.</xsd:documentation>
+					<xsd:documentation>Maximum Limit as percentage of whole price.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MaximumLimitPrice" type="CurrencyAmountType" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
@@ -108,7 +108,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="ProvidesCard" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether the product provdies a card with it.</xsd:documentation>
+					<xsd:documentation>Whether the product provides a card with it.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GoesOnCard" type="xsd:boolean" default="false" minOccurs="0">
@@ -167,27 +167,27 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="HasOperatorRestrictions" type="OperatorRestrictionsEnumeration" default="anyTrain" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Restictions on which OPERATOR's services can be used.</xsd:documentation>
+					<xsd:documentation>Restrictions on which OPERATOR's services can be used.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="HasTravelTimeRestrictions" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether there are restictions on which routes can be used.</xsd:documentation>
+					<xsd:documentation>Whether there are restrictions on which routes can be used.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="HasRouteRestrictions" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether there are restictions on which routes can be used.</xsd:documentation>
+					<xsd:documentation>Whether there are restrictions on which routes can be used.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="TrainRestrictions" type="TrainRestrictionsEnumeration" default="anyTrain" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Restictions on which trains can be used.</xsd:documentation>
+					<xsd:documentation>Restrictions on which trains can be used.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="HasZoneRestrictions" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether there are restictions on which zones can be used.</xsd:documentation>
+					<xsd:documentation>Whether there are restrictions on which zones can be used.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="CanBreakJourney" type="xsd:boolean" default="false" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
@@ -394,7 +394,7 @@ The RULE STEP RESULT  Adjustment Amount is  the difference between the original 
 			</xsd:group>
 			<xsd:element name="Narrative" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Explanation of calcuation step as text. +v1.1</xsd:documentation>
+					<xsd:documentation>Explanation of calculation step as text. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_support.xsd
@@ -88,7 +88,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="ServiceAccessRightRefGroup">
 		<xsd:annotation>
-			<xsd:documentation>Any one of the alllowed SERVICE ACCESS RIGHT.</xsd:documentation>
+			<xsd:documentation>Any one of the allowed SERVICE ACCESS RIGHT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="ServiceAccessRightRef"/>
@@ -155,7 +155,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="FareProductRefGroup">
 		<xsd:annotation>
-			<xsd:documentation>Any one of the alllowed fare products.</xsd:documentation>
+			<xsd:documentation>Any one of the allowed fare products.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="FareProductRef"/>
@@ -996,7 +996,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="PreassignedFareProductType" type="PreassignedFareProductEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Classifcation of a PREASSIGNED FARE PRODUCT.</xsd:documentation>
+					<xsd:documentation>Classification of a PREASSIGNED FARE PRODUCT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="SupplementProductType" type="SupplementProductEnumeration" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
@@ -196,7 +196,7 @@
 			</xsd:element>
 			<xsd:element name="SymbolMarkingUsualRoute" type="xsd:normalizedString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Symbal to us eto mark normal route.</xsd:documentation>
+					<xsd:documentation>Symbal to use to mark normal route.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -213,7 +213,7 @@
 			</xsd:element>
 			<xsd:element name="RoutingType" type="RoutingTypeEnumeration" default="both" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether this is a direct i.e. no changes requried point to point or indirect.</xsd:documentation>
+					<xsd:documentation>Whether this is a direct i.e. no changes required point to point or indirect.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
@@ -100,7 +100,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:complexType name="fareStructureElementsInFrame_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for containment in frame of FARE STUCTURE ELEMENTs.</xsd:documentation>
+			<xsd:documentation>Type for containment in frame of FARE STRUCTURE ELEMENTs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
@@ -227,7 +227,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfTariffRef" minOccurs="0"/>
 			<xsd:element name="TariffBasis" type="TariffBasisEnumeration" default="route" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Classification of Tariff Butasis. Defaut is Route (Tap TSI)</xsd:documentation>
+					<xsd:documentation>Classification of Tariff Butasis. Default is Route (Tap TSI)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ReturnFareTwiceSingle" type="xsd:boolean" default="true" minOccurs="0">
@@ -476,7 +476,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="FareStructureElementFactorGroup">
 		<xsd:annotation>
-			<xsd:documentation>FARE STRCUTURE FACTOR Elements for a FARE STRUCTURE ELEMENT.</xsd:documentation>
+			<xsd:documentation>FARE STRUCTURE FACTOR Elements for a FARE STRUCTURE ELEMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:choice minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
@@ -303,7 +303,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="FareTableHeadingsGroup">
 		<xsd:annotation>
-			<xsd:documentation>PriceHeading lements for a FARE TABLE.</xsd:documentation>
+			<xsd:documentation>PriceHeading elements for a FARE TABLE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="columns" type="fareTableColumns_RelStructure" minOccurs="0">
@@ -588,7 +588,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="CellHeadingsGroup"/>
 			<xsd:element name="noticeAssignments" type="noticeAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>NOTICE relating to CElll</xsd:documentation>
+					<xsd:documentation>NOTICE relating to cell</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -683,7 +683,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="DirectionType" type="RelativeDirectionEnumeration" default="both" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>For fares for DISTANCE MATRIXE LEMENTs, DIRECTION in which price applies.</xsd:documentation>
+					<xsd:documentation>For fares for DISTANCE MATRIX ELEMENTs, DIRECTION in which price applies.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="RoutingType" type="RoutingTypeEnumeration" default="both" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RequiresEmailAddress" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether use of the channel requries the pruchaser to have an email address.</xsd:documentation>
+					<xsd:documentation>Whether use of the channel requires the pruchaser to have an email address.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ContactDetails" type="ContactStructure" minOccurs="0">
@@ -210,7 +210,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="DistributionRights" type="DistributionRightsListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Defaut distribution Rigts allowed by DISTRIBUTION CHANNEL.</xsd:documentation>
+					<xsd:documentation>Default distribution Rigts allowed by DISTRIBUTION CHANNEL.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -481,7 +481,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="SalesOfferPackageRef" minOccurs="0"/>
 			<xsd:element name="WithSalesOfferPackageRef" type="SalesOfferPackageRefStructure">
 				<xsd:annotation>
-					<xsd:documentation>SALES OFFER PACKAGE that may be used to subsitute base SALES OFFER PACKAGE.</xsd:documentation>
+					<xsd:documentation>SALES OFFER PACKAGE that may be used to substitute base SALES OFFER PACKAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -664,7 +664,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="DistributionProductsGroup"/>
 			<xsd:element name="DistributionRights" type="DistributionRightsListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Override the folloing rights allowed by channel.</xsd:documentation>
+					<xsd:documentation>Override the following rights allowed by channel.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="DistributionThroughGroup"/>
@@ -736,17 +736,17 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="InitialCarrier" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Wehther initial carrer has rights.</xsd:documentation>
+					<xsd:documentation>Whether initial carrier has rights.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="TransitCarrier" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whther intremediate transit carrier has rights.</xsd:documentation>
+					<xsd:documentation>Whether intremediate transit carrier has rights.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="FinalCarrier" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whetehr final carrier has rights.</xsd:documentation>
+					<xsd:documentation>Whether final carrier has rights.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="OneOrAllOrganisationsRefGroup" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_trip_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_trip_support.xsd
@@ -60,7 +60,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:group name="TripReferenceGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elemenst for references to a Trip</xsd:documentation>
+			<xsd:documentation>Elements for references to a Trip</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="TripPatternRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_version.xsd
@@ -152,7 +152,7 @@ Rail transport, Roads and Road transport
 							</xsd:element>
 							<xsd:element name="typesOfMachineReadabilities" type="typesOfMachineReadabilities_RelStructure" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Openended classiifcation of machine readable capabilties compatible with TRAVEL DOCUMENT.</xsd:documentation>
+									<xsd:documentation>Openended classiifcation of machine readable capabilities compatible with TRAVEL DOCUMENT.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element name="alternativeNames" type="alternativeNames_RelStructure" minOccurs="0">
@@ -209,7 +209,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="typesOfMachineReadabilities" type="typesOfMachineReadabilities_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Openended classiifcation of machine readable capabilties compatible with TRAVEL DOCUMENT.</xsd:documentation>
+					<xsd:documentation>Openended classiifcation of machine readable capabilities compatible with TRAVEL DOCUMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="alternativeNames" type="alternativeNames_RelStructure" minOccurs="0">
@@ -234,7 +234,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="TypeOfMachineReadability" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
-			<xsd:documentation>A classification of MACHINE REDABILITY capabailities, used for example to indicate how a TRAVEL DOCUMENT may be read.</xsd:documentation>
+			<xsd:documentation>A classification of MACHINE READABILITY capabailities, used for example to indicate how a TRAVEL DOCUMENT may be read.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
@@ -313,7 +313,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="partialJourney">
 				<xsd:annotation>
-					<xsd:documentation>Refund is for unusued section of a journey.</xsd:documentation>
+					<xsd:documentation>Refund is for unused section of a journey.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="earlyTermination">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -145,7 +145,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="ResellingCalculationGroup"/>
 			<xsd:group ref="ResellingPaymentGroup">
 				<xsd:annotation>
-					<xsd:documentation>Elements for making payments fo RESELLING Group.</xsd:documentation>
+					<xsd:documentation>Elements for making payments for RESELLING Group.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 		</xsd:sequence>
@@ -245,7 +245,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="typesOfPaymentMethodRef" type="TypeOfPaymentMethodRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Other PAYMENT METHODs allowd to pay fee or to make refund.</xsd:documentation>
+					<xsd:documentation>Other PAYMENT METHODs allowed to pay fee or to make refund.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="blockAllTravel">
 				<xsd:annotation>
-					<xsd:documentation>Policy if credit threhsold is exceeded is to block all travel bu yuser.</xsd:documentation>
+					<xsd:documentation>Policy if credit threhsold is exceeded is to block all travel by user.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="blockPayAsYouGoTravel">
@@ -157,7 +157,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="billAtFareDayEnd">
 				<xsd:annotation>
-					<xsd:documentation>Bill at end of evey fare day.</xsd:documentation>
+					<xsd:documentation>Bill at end of every fare day.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="billAtPeriodEnd">
@@ -325,7 +325,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="variable">
 				<xsd:annotation>
-					<xsd:documentation>Subscription can be for an arbitray term,</xsd:documentation>
+					<xsd:documentation>Subscription can be for an arbitrary term,</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="openEnded">
@@ -342,7 +342,7 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="automatic">
 				<xsd:annotation>
-					<xsd:documentation>Renew automatcally at end of term.</xsd:documentation>
+					<xsd:documentation>Renew automatically at end of term.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="manual">
@@ -352,7 +352,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="automaticOnConfirmation">
 				<xsd:annotation>
-					<xsd:documentation>Confirm and renew automatcally at end of subscription term.</xsd:documentation>
+					<xsd:documentation>Confirm and renew automatically at end of subscription term.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="none">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
@@ -204,7 +204,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MaximumNumberOfFailToCheckOutEvents" type="xsd:integer" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Lmit on the number of fail-to-checkout events allowed before suspension. +v1.1</xsd:documentation>
+					<xsd:documentation>Limit on the number of fail-to-checkout events allowed before suspension. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -267,7 +267,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="SubscriptionTermType" type="SubscriptionTermTypeEnumeration" default="fixed" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Type of susbcription term, e.g. fixed, variable, etc.</xsd:documentation>
+					<xsd:documentation>Type of subscription term, e.g. fixed, variable, etc.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MinimumSubscriptionPeriod" type="xsd:duration" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_support.xsd
@@ -665,7 +665,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="automaticallySubstituteProduct"/>
 			<xsd:enumeration value="noAction">
 				<xsd:annotation>
-					<xsd:documentation>If user ceases to be eligible, automatically substitute them with an appropiate replacement product.</xsd:documentation>
+					<xsd:documentation>If user ceases to be eligible, automatically substitute them with an appropriate replacement product.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="other"/>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -466,7 +466,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="ParentRef" type="UsageParameterRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this specifes the member rules.</xsd:documentation>
+					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this specifies the member rules.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="UserProfileRef" minOccurs="0"/>
@@ -562,7 +562,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="ParentRef" type="UsageParameterRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this specifes the member rules.</xsd:documentation>
+					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this specifies the member rules.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MustReside" type="xsd:boolean" minOccurs="0">
@@ -573,7 +573,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TopographicPlaceRef" minOccurs="0"/>
 			<xsd:element name="ResidenceType" type="ResidenceTypeEnumeration" default="live" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Classifcation of type of residence required, e.g. live, work, study.</xsd:documentation>
+					<xsd:documentation>Classification of type of residence required, e.g. live, work, study.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MinimumDuration" type="xsd:duration" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd
@@ -218,7 +218,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="PeriodConstraint" type="SamePeriodEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Constraints on valdity period.</xsd:documentation>
+					<xsd:documentation>Constraints on validity period.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
@@ -590,7 +590,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="SuspensionPolicyListOfEnumerations">
 		<xsd:annotation>
-			<xsd:documentation>List of Suspension Policiy values</xsd:documentation>
+			<xsd:documentation>List of Suspension Policy values</xsd:documentation>
 		</xsd:annotation>
 		<xsd:list itemType="SuspensionPolicyEnumeration"/>
 	</xsd:simpleType>
@@ -607,7 +607,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="unlimited">
 				<xsd:annotation>
-					<xsd:documentation>Unlimted use may be made of the product within allowed period.</xsd:documentation>
+					<xsd:documentation>Unlimited use may be made of the product within allowed period.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="limited">

--- a/xsd/netex_part_3/part3_parkingTariff/netex_parkingTariff_version.xsd
+++ b/xsd/netex_part_3/part3_parkingTariff/netex_parkingTariff_version.xsd
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="vehicleTypes" type="transportTypeRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Opnen specifcation of VEHICLE TYPEs + v1.1</xsd:documentation>
+					<xsd:documentation>Opnen specification of VEHICLE TYPEs + v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="appliesTo" type="parkingRefs_RelStructure" minOccurs="0">

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPaymentMeans_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPaymentMeans_support.xsd
@@ -54,7 +54,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx CUSTOMER PAYMENT MEANS Identifer types for</xsd:documentation>
+		<xsd:documentation>NeTEx CUSTOMER PAYMENT MEANS Identifier types for</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ====  CUSTOMER PAYMENT MEANS. ============================================ -->

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
@@ -228,7 +228,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:complexType name="SpecificParameterAssignmentRefStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for Reference to a SPECIFIC PARAMETER ASIGNMENT..</xsd:documentation>
+			<xsd:documentation>Type for Reference to a SPECIFIC PARAMETER ASSIGNMENT..</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:restriction base="ValidityParameterAssignmentRefStructure">

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -254,7 +254,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="TravelSpecificationPriceGroup">
 		<xsd:annotation>
-			<xsd:documentation>Price lements for TRAVEL SPECIFICATION.</xsd:documentation>
+			<xsd:documentation>Price elements for TRAVEL SPECIFICATION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:choice minOccurs="0">
@@ -475,7 +475,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="includes" type="specificParameterAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Assignments Logically included in this group. Groups are combined acording to the Operator.</xsd:documentation>
+					<xsd:documentation>Assignments Logically included in this group. Groups are combined according to the Operator.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_support.xsd
@@ -54,7 +54,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx MEDIUM ACCESS DEVICE Identifer types for</xsd:documentation>
+		<xsd:documentation>NeTEx MEDIUM ACCESS DEVICE Identifier types for</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ====  MEDIUM ACCESS DEVICE ============================================ -->

--- a/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_support.xsd
@@ -62,7 +62,7 @@ Rail transport, Roads and Road transport
 	<!-- ==== RETAIL CONSORTIUM.======================================================== -->
 	<xsd:complexType name="retailConsortiumRefs_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of referecnes to RETAIL CONSORTIUMs.</xsd:documentation>
+			<xsd:documentation>Type for a list of references to RETAIL CONSORTIUMs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
@@ -488,7 +488,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="TypeOfFareContractEntryRef" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>A classifiication of FARE CONTRACT ENTRYs.</xsd:documentation>
+					<xsd:documentation>A classification of FARE CONTRACT ENTRYs.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="FareContractRef" minOccurs="0"/>
@@ -702,7 +702,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="customerPurchasePackages" type="customerPurchasePackageRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>CUSTOMER PURCHASE PACKAGES for CUSTOMER ACCOUT.</xsd:documentation>
+					<xsd:documentation>CUSTOMER PURCHASE PACKAGES for CUSTOMER ACCOUNT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="CustomerPaymentMeansRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_version.xsd
@@ -183,7 +183,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="travelSpecifications" type="travelSpecifications_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Travel Specifcations bought by Salles Transaction</xsd:documentation>
+					<xsd:documentation>Travel Specifications bought by Salles Transaction</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="customerPurchasePackages" type="customerPurchasePackages_RelStructure" minOccurs="0">

--- a/xsd/netex_part_3/part3_salesTransactions/netex_spotAllocation_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_spotAllocation_version.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="DatedVehicleJourneyRef" minOccurs="0"/>
 			<xsd:element name="SeatAllocationMethod" type="SeatAllocationMethodEnumeration" default="autoAssigned" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Method used to allocate seat. Defult is autoassigned</xsd:documentation>
+					<xsd:documentation>Method used to allocate seat. Default is autoassigned</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="SpotAllocationMethodRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_travelSpecificationSummary_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_travelSpecificationSummary_version.xsd
@@ -102,7 +102,7 @@ Rail transport, Roads and Road transport
 	<xsd:include schemaLocation="../../netex_part_5/part5_rc/netex_nm_mobilityService_support.xsd"/>
 	<xsd:element name="TravelSpecificationSummaryView" type="TravelSpecificationSummaryViewStructure">
 		<xsd:annotation>
-			<xsd:documentation>Summary of key aspects of TRAVEL SPECIFICATION. +V1.1. This data should all be derivable from the PARAMATER ASSIGNMENTs. v+1.1</xsd:documentation>
+			<xsd:documentation>Summary of key aspects of TRAVEL SPECIFICATION. +V1.1. This data should all be derivable from the PARAMETER ASSIGNMENTs. v+1.1</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="TravelSpecificationSummaryViewStructure">
@@ -122,7 +122,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:group ref="TravelSpecificationSummaryJourneyGroup">
 				<xsd:annotation>
-					<xsd:documentation>Travel lements for TRAVEL SPECIFICATION.</xsd:documentation>
+					<xsd:documentation>Travel elements for TRAVEL SPECIFICATION.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:group ref="TravelSpecificationSummaryFareGroup"/>
@@ -133,7 +133,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:complexType name="TravelSpecificationSummaryEndpointStructure">
 		<xsd:annotation>
-			<xsd:documentation>Origin or destnation elements for TRAVEL SPECIFICATION Summary View.</xsd:documentation>
+			<xsd:documentation>Origin or destination elements for TRAVEL SPECIFICATION Summary View.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:group ref="TravelSpecificationSummaryEndPointPlaceGroup"/>
@@ -257,7 +257,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="ServiceFacilitySet" minOccurs="0"/>
 			<xsd:element name="seatEquipments" type="equipments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Equipments assocated with Seat</xsd:documentation>
+					<xsd:documentation>Equipments associated with Seat</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_support.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_support.xsd
@@ -55,7 +55,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx VEHICLE ACCESS CREDENTIALS ASSIGNMENT Identifer types for</xsd:documentation>
+		<xsd:documentation>NeTEx VEHICLE ACCESS CREDENTIALS ASSIGNMENT Identifier types for</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ====  Service Acess code ASSIGNMENT ============================================ -->

--- a/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_support.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_support.xsd
@@ -54,7 +54,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx INDIVIDUAL TRAVELLER Identifer types for</xsd:documentation>
+		<xsd:documentation>NeTEx INDIVIDUAL TRAVELLER Identifier types for</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ====  INDIVIDUAL TRAVELLER ============================================ -->
@@ -248,7 +248,7 @@ Rail transport, Roads and Road transport
 	<!-- ====  USER RANKING  ============================================ -->
 	<xsd:simpleType name="UserRankingType">
 		<xsd:annotation>
-			<xsd:documentation>Individual ranking based on the traditional 5 stars (1 to 5, 5 being the better) ranking which is the most used (note that the Like/Dislike model can be mapped to no-ranking/ranking=1 and the rare 10 stars model, like IMDb, will mapp 1/2 ti 1, 2/3 to 2, etc.)</xsd:documentation>
+			<xsd:documentation>Individual ranking based on the traditional 5 stars (1 to 5, 5 being the better) ranking which is the most used (note that the Like/Dislike model can be mapped to no-ranking/ranking=1 and the rare 10 stars model, like IMDb, will map 1/2 ti 1, 2/3 to 2, etc.)</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:positiveInteger">
 			<xsd:minInclusive value="1"/>
@@ -257,7 +257,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="GlobalRankingType">
 		<xsd:annotation>
-			<xsd:documentation>Mean ranking based on the traditional 5 stars (1 to 5 better) ranking which is the most used (note that the Like/Dislike model can be mapped to no-ranking/ranking=1 and the rare 10 stars model, like IMDb, will mapp 1/2 ti 1, 2/3 to 2, etc.)</xsd:documentation>
+			<xsd:documentation>Mean ranking based on the traditional 5 stars (1 to 5 better) ranking which is the most used (note that the Like/Dislike model can be mapped to no-ranking/ranking=1 and the rare 10 stars model, like IMDb, will map 1/2 ti 1, 2/3 to 2, etc.)</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:decimal">
 			<xsd:minInclusive value="1.0"/>

--- a/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_version.xsd
@@ -274,7 +274,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="DrivingStyle" type="DrivingStyleEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Preferrred style of driving.</xsd:documentation>
+					<xsd:documentation>Preferred style of driving.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="NumberOfProposedTrips" type="xsd:nonNegativeInteger" minOccurs="0">

--- a/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
@@ -242,7 +242,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="NumberOFDrivers" type="xsd:nonNegativeInteger" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maximimum Number of drivers allwoed.</xsd:documentation>
+					<xsd:documentation>Maximum Number of drivers allowed.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_version.xsd
@@ -115,7 +115,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="RuleApplicability" type="ZoneRuleApplicabilityEnumeration" default="inside" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Applicability of rule inside (defaut) or outside of zone</xsd:documentation>
+					<xsd:documentation>Applicability of rule inside (default) or outside of zone</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ZoneUse" type="TransportZoneUseEnumeration" minOccurs="0">
@@ -297,7 +297,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MustReturnToSameBay" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether a VEICLE must be returned to same bay as it was was taken from.</xsd:documentation>
+					<xsd:documentation>Whether a VEHICLE must be returned to same bay as it was was taken from.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_support.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_support.xsd
@@ -54,7 +54,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx VEHICLE SERVICE PLACE ASSIGNMENT Identifer types for</xsd:documentation>
+		<xsd:documentation>NeTEx VEHICLE SERVICE PLACE ASSIGNMENT Identifier types for</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ==== VEHICLE SERVICE PLACE ASSIGNMENT ============================================ -->

--- a/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_support.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_support.xsd
@@ -55,7 +55,7 @@ Rail transport, Roads and Road transport
 	<!-- ===== MOBILITY SERVICE===================================================== -->
 	<xsd:complexType name="mobilityServiceRefs_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of refernces to MOBILITY SERVICEs.</xsd:documentation>
+			<xsd:documentation>Type for a list of references to MOBILITY SERVICEs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">

--- a/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
@@ -207,7 +207,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="proposedByServices" type="onlineServiceRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Online servicies proposing this service,</xsd:documentation>
+					<xsd:documentation>Online services proposing this service,</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -520,7 +520,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MinimumSharingPeriod" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Minmum time period for sharing.</xsd:documentation>
+					<xsd:documentation>Minimum time period for sharing.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MaximumSharingPeriod" type="xsd:duration" minOccurs="0">
@@ -602,7 +602,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MinimumRentalPeriod" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Minmum time period for rental;</xsd:documentation>
+					<xsd:documentation>Minimum time period for rental;</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="RentalPolicyUrl" type="xsd:anyURI" minOccurs="0">

--- a/xsd/netex_service/netex_dataObjectRequest_service.xsd
+++ b/xsd/netex_service/netex_dataObjectRequest_service.xsd
@@ -92,7 +92,7 @@ Roads and road transport</Category>
 		<xsd:sequence>
 			<xsd:element name="topics">
 				<xsd:annotation>
-					<xsd:documentation>One or more Request filters that specify tthe data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
+					<xsd:documentation>One or more Request filters that specify the data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>

--- a/xsd/netex_service/netex_filter_frame.xsd
+++ b/xsd/netex_service/netex_filter_frame.xsd
@@ -112,7 +112,7 @@ Roads and road transport
 				<xsd:sequence>
 					<xsd:group ref="NetworkFilterByValueGroup">
 						<xsd:annotation>
-							<xsd:documentation>Values for selcting by value. Return objuects that satisfy alll of the follwoing.</xsd:documentation>
+							<xsd:documentation>Values for selecting by value. Return objuects that satisfy all of the following.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:group>
 				</xsd:sequence>

--- a/xsd/siri_utility/siri_location-v2.0.xsd
+++ b/xsd/siri_utility/siri_location-v2.0.xsd
@@ -162,7 +162,7 @@ Rail transport, Roads and road transport
 				</xsd:sequence>
 				<xsd:element name="Coordinates" type="CoordinatesStructure">
 					<xsd:annotation>
-						<xsd:documentation>Coordinates of points in a GML compatibe format, as indicated by srsName attribute.</xsd:documentation>
+						<xsd:documentation>Coordinates of points in a GML compatible format, as indicated by srsName attribute.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -221,13 +221,13 @@ Lower right corner.
 	<!--======Distance ============================================================-->
 	<xsd:simpleType name="DistanceType">
 		<xsd:annotation>
-			<xsd:documentation>Distance (metres) as defined by http://www.ordnancesurvey.co.uk/xml/resource/units.xml#metres. ALternative units may be specifed by context.</xsd:documentation>
+			<xsd:documentation>Distance (metres) as defined by http://www.ordnancesurvey.co.uk/xml/resource/units.xml#metres. ALternative units may be specified by context.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:nonNegativeInteger"/>
 	</xsd:simpleType>
 	<xsd:simpleType name="VelocityType">
 		<xsd:annotation>
-			<xsd:documentation>Distance (metres per second) ALternative unist may be specifed by context.</xsd:documentation>
+			<xsd:documentation>Distance (metres per second) ALternative unist may be specified by context.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:nonNegativeInteger"/>
 	</xsd:simpleType>

--- a/xsd/siri_utility/siri_permissions-v2.0.xsd
+++ b/xsd/siri_utility/siri_permissions-v2.0.xsd
@@ -101,7 +101,7 @@ Rail transport, Roads and road transport
 			<xsd:choice>
 				<xsd:element name="AllParticipants" type="EmptyType">
 					<xsd:annotation>
-						<xsd:documentation>Parmissions apply by default to All particpants. May be overidden by other separate permissions for individual.</xsd:documentation>
+						<xsd:documentation>Parmissions apply by default to All participants. May be overridden by other separate permissions for individual.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ParticipantRef" type="ParticipantRefStructure">

--- a/xsd/siri_utility/siri_types-v2.0.xsd
+++ b/xsd/siri_utility/siri_types-v2.0.xsd
@@ -77,7 +77,7 @@
 	</xsd:simpleType>
 	<xsd:complexType name="NaturalLanguageStringStructure">
 		<xsd:annotation>
-			<xsd:documentation>Tyoe for a string in a specified language.</xsd:documentation>
+			<xsd:documentation>Type for a string in a specified language.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:extension base="PopulatedStringType">

--- a/xsd/wsdl/NeTEx_publication-NoConstraint.xsd
+++ b/xsd/wsdl/NeTEx_publication-NoConstraint.xsd
@@ -88,13 +88,13 @@ Roads and Road transport.
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 			<xsd:element name="topics" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>One or more Request filters that specify tthe data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
+					<xsd:documentation>One or more Request filters that specify the data to be included in output. Multiple filters are logically ANDed.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>
 						<xsd:element name="NetworkFrameTopic" type="NetworkFrameTopicStructure" maxOccurs="unbounded">
 							<xsd:annotation>
-								<xsd:documentation>Vaues to use select Network Objects.</xsd:documentation>
+								<xsd:documentation>Values to use select Network Objects.</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:sequence>

--- a/xsd/ynotation/netex_thing_support.xsd
+++ b/xsd/ynotation/netex_thing_support.xsd
@@ -124,7 +124,7 @@
 				<xsd:sequence>
 					<xsd:element ref="TypeOfThingRef" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
-							<xsd:documentation>Refernce to a TYPE OF THING.</xsd:documentation>
+							<xsd:documentation>Reference to a TYPE OF THING.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>


### PR DESCRIPTION
## Issue

The schemas contain a large number of typos in `<xsd:documentation>` text (Like `CEN tral African Republic`).

## Fix

Corrected issues found within `<xsd:documentation>` .

- **CAPS Transmodel object names keep their plural `s`** — only the misspelling
  inside the name is corrected, e.g. `JORUNEY` → `JOURNEY`, `INFRASTUCTURE` →
  `INFRASTRUCTURE`, `POSTION` → `POSITION`. Correct object plurals such as
  `EQUIPMENTs` and `ENTRYs` are left untouched.
