### PR TITLE
Fix broken relative schemaLocation paths in WSDL files

### DIFF
--- a/xsd/wsdl/NeTEx_publication-NoConstraint.xsd
+++ b/xsd/wsdl/NeTEx_publication-NoConstraint.xsd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_publication">
 	<!-- ===SIRI system IDs for  request =========================================================== -->
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_base-v2.0.xsd"/>
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri_utility/siri_participant-v2.0.xsd"/>
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_requests-v2.0.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri/siri_base-v2.0.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri_utility/siri_participant-v2.0.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri/siri_requests-v2.0.xsd"/>
 	<!-- ===Regular netex============================================================== -->
-	<xsd:include schemaLocation="netex_service/netex_dataObjectRequest_service.xsd"/>
-	<xsd:include schemaLocation="netex_service/netex_all.xsd"/>
+	<xsd:include schemaLocation="../netex_service/netex_dataObjectRequest_service.xsd"/>
+	<xsd:include schemaLocation="../netex_service/netex_all.xsd"/>
 	<!-- ===eGIF/GovTalk Documentation ======================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>

--- a/xsd/wsdl_model/siri_wsConsumer-Framework.xsd
+++ b/xsd/wsdl_model/siri_wsConsumer-Framework.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.3" id="siriWS">
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siriSg.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri/siri_all_framework-v2.0.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">

--- a/xsd/wsdl_model/siri_wsConsumer-Services.xsd
+++ b/xsd/wsdl_model/siri_wsConsumer-Services.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://wsdl.siri.org.uk" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://wsdl.siri.org.uk" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.3" id="siriWS">
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri/siri_all_framework-v2.0.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">

--- a/xsd/wsdl_model/siri_wsProducer-DiscoveryCapability.xsd
+++ b/xsd/wsdl_model/siri_wsProducer-DiscoveryCapability.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://wsdl.siri.org.uk" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://wsdl.siri.org.uk" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.3" id="siriWS">
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri/siri_all_framework-v2.0.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">

--- a/xsd/wsdl_model/siri_wsProducer-Services.xsd
+++ b/xsd/wsdl_model/siri_wsProducer-Services.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://wsdl.siri.org.uk" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://wsdl.siri.org.uk" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.3" id="siriWS">
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../siri/siri_all_framework-v2.0.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">


### PR DESCRIPTION
Fixes 5 files that fail to compile standalone (`xmllint --schema`) because of broken relative `schemaLocation`/`import` paths — either missing a `../` for their actual directory depth, or pointing at filenames that no longer exist:

| File | Before | After |
|---|---|---|
| `xsd/wsdl/NeTEx_publication-NoConstraint.xsd` | `siri/siri_base-v2.0.xsd`, `siri_utility/siri_participant-v2.0.xsd`, `siri/siri_requests-v2.0.xsd`, `netex_service/netex_dataObjectRequest_service.xsd`, `netex_service/netex_all.xsd` (all missing `../`) | same paths, each prefixed with `../` |
| `xsd/wsdl_model/siri_wsConsumer-Framework.xsd` `xsd/wsdl_model/siri_wsProducer-Services.xsd` `xsd/wsdl_model/siri_wsProducer-DiscoveryCapability.xsd` `xsd/wsdl_model/siri_wsConsumer-Services.xsd` | `../siri.xsd` (doesn't exist) | `../siri/siri_all_framework-v2.0.xsd` |

**Note**: 3 of these files reference SIRI functional-service types that were never vendored into this repo, see #1069 
